### PR TITLE
Use generic 'asset' type for items in information screen

### DIFF
--- a/schemas/v1.json
+++ b/schemas/v1.json
@@ -282,9 +282,7 @@
           "type": "string",
           "enum": [
             "text",
-            "image",
-            "audio",
-            "video"
+            "asset"
           ]
         },
         "content": {


### PR DESCRIPTION
Asset type will be defined in `assetManifest` so this is redundant information.