### PR TITLE
Precompile validators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
@@ -39,6 +44,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+    },
+    "ajv-pack": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ajv-pack/-/ajv-pack-0.3.1.tgz",
+      "integrity": "sha1-tyxNQhnjko5ihC10Le2Tv1B5ZWA=",
+      "requires": {
+        "js-beautify": "^1.6.4",
+        "require-from-string": "^1.2.0"
+      }
     },
     "ansi-escapes": {
       "version": "3.2.0",
@@ -338,6 +352,15 @@
         "typedarray": "^0.0.6"
       }
     },
+    "config-chain": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -395,6 +418,17 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "requires": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
       }
     },
     "emoji-regex": {
@@ -821,6 +855,16 @@
         "write": "^0.2.1"
       }
     },
+    "fs-extra": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.0.1.tgz",
+      "integrity": "sha512-W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -927,6 +971,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
@@ -1012,6 +1061,18 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
+    "js-beautify": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.0.tgz",
+      "integrity": "sha512-OMwf/tPDpE/BLlYKqZOhqWsd3/z2N3KOlyn1wsCRGFwViE8LOQTcDtathQvHvZc+q+zWmcNAbwKSC+iJoMaH2Q==",
+      "requires": {
+        "config-chain": "^1.1.12",
+        "editorconfig": "^0.15.3",
+        "glob": "^7.1.3",
+        "mkdirp": "~0.5.1",
+        "nopt": "~4.0.1"
+      }
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -1049,6 +1110,14 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsx-ast-utils": {
@@ -1198,6 +1267,15 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
+    "nopt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+      "requires": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -1264,10 +1342,24 @@
         "wordwrap": "~1.0.0"
       }
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "p-limit": {
       "version": "1.3.0",
@@ -1390,6 +1482,11 @@
         "react-is": "^16.8.1"
       }
     },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -1457,6 +1554,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw=="
+    },
+    "require-from-string": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -1550,6 +1652,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -1718,6 +1825,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "main": "index.js",
   "scripts": {
     "validate-protocol": "node scripts/validate-protocol.js",
+    "build": "node scripts/build-schemas.js",
     "lint": "eslint ."
   },
   "repository": {
@@ -24,15 +25,17 @@
   "homepage": "https://github.com/codaco/protocol-validation",
   "dependencies": {
     "ajv": "^6.10.0",
+    "ajv-pack": "^0.3.1",
     "babel-eslint": "7.2.3",
     "chalk": "^2.4.2",
-    "jszip": "^3.2.1",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^15.0.1",
     "eslint-loader": "1.9.0",
-    "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-flowtype": "2.35.0",
     "eslint-plugin-import": "2.7.0",
-    "eslint-plugin-jsx-a11y": "5.1.1"
+    "eslint-plugin-jsx-a11y": "5.1.1",
+    "eslint-plugin-react": "^7.11.1",
+    "fs-extra": "^8.0.1",
+    "jszip": "^3.2.1"
   }
 }

--- a/schemas/index.js
+++ b/schemas/index.js
@@ -1,5 +1,3 @@
-const v1 = require('./v1.json');
+const v1 = require('./v1.js');
 
-module.exports = {
-  v1,
-};
+module.exports = { v1 };

--- a/schemas/v1.js
+++ b/schemas/v1.js
@@ -1,0 +1,7427 @@
+'use strict';
+var formats = require('ajv/lib/compile/formats')();
+var equal = require('ajv/lib/compile/equal');
+var validate = (function() {
+  var pattern0 = new RegExp('.+');
+  var refVal = [];
+  var refVal1 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'name' || key0 == 'description' || key0 == 'lastModified' || key0 == 'schemaVersion' || key0 == 'codebook' || key0 == 'assetManifest' || key0 == 'stages');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            if (data.name === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'name'
+                },
+                message: 'should have required property \'name\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              if (typeof data.name !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.name',
+                  schemaPath: '#/properties/name/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              if (data.description === undefined) {
+                valid1 = true;
+              } else {
+                var errs_1 = errors;
+                if (typeof data.description !== "string") {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.description',
+                    schemaPath: '#/properties/description/type',
+                    params: {
+                      type: 'string'
+                    },
+                    message: 'should be string'
+                  }];
+                  return false;
+                }
+                var valid1 = errors === errs_1;
+              }
+              if (valid1) {
+                var data1 = data.lastModified;
+                if (data1 === undefined) {
+                  valid1 = true;
+                } else {
+                  var errs_1 = errors;
+                  if (errors === errs_1) {
+                    if (typeof data1 === "string") {
+                      if (!formats['date-time'].test(data1)) {
+                        validate.errors = [{
+                          keyword: 'format',
+                          dataPath: (dataPath || '') + '.lastModified',
+                          schemaPath: '#/properties/lastModified/format',
+                          params: {
+                            format: 'date-time'
+                          },
+                          message: 'should match format "date-time"'
+                        }];
+                        return false;
+                      }
+                    } else {
+                      validate.errors = [{
+                        keyword: 'type',
+                        dataPath: (dataPath || '') + '.lastModified',
+                        schemaPath: '#/properties/lastModified/type',
+                        params: {
+                          type: 'string'
+                        },
+                        message: 'should be string'
+                      }];
+                      return false;
+                    }
+                  }
+                  var valid1 = errors === errs_1;
+                }
+                if (valid1) {
+                  if (data.schemaVersion === undefined) {
+                    valid1 = true;
+                  } else {
+                    var errs_1 = errors;
+                    if (typeof data.schemaVersion !== "string") {
+                      validate.errors = [{
+                        keyword: 'type',
+                        dataPath: (dataPath || '') + '.schemaVersion',
+                        schemaPath: '#/properties/schemaVersion/type',
+                        params: {
+                          type: 'string'
+                        },
+                        message: 'should be string'
+                      }];
+                      return false;
+                    }
+                    var valid1 = errors === errs_1;
+                  }
+                  if (valid1) {
+                    if (data.codebook === undefined) {
+                      valid1 = false;
+                      validate.errors = [{
+                        keyword: 'required',
+                        dataPath: (dataPath || '') + "",
+                        schemaPath: '#/required',
+                        params: {
+                          missingProperty: 'codebook'
+                        },
+                        message: 'should have required property \'codebook\''
+                      }];
+                      return false;
+                    } else {
+                      var errs_1 = errors;
+                      if (!refVal2(data.codebook, (dataPath || '') + '.codebook', data, 'codebook', rootData)) {
+                        if (vErrors === null) vErrors = refVal2.errors;
+                        else vErrors = vErrors.concat(refVal2.errors);
+                        errors = vErrors.length;
+                      }
+                      var valid1 = errors === errs_1;
+                    }
+                    if (valid1) {
+                      var data1 = data.assetManifest;
+                      if (data1 === undefined) {
+                        valid1 = true;
+                      } else {
+                        var errs_1 = errors;
+                        var errs_2 = errors;
+                        if ((!data1 || typeof data1 !== "object" || Array.isArray(data1))) {
+                          validate.errors = [{
+                            keyword: 'type',
+                            dataPath: (dataPath || '') + '.assetManifest',
+                            schemaPath: '#/definitions/AssetManifest/type',
+                            params: {
+                              type: 'object'
+                            },
+                            message: 'should be object'
+                          }];
+                          return false;
+                        }
+                        var valid2 = errors === errs_2;
+                        var valid1 = errors === errs_1;
+                      }
+                      if (valid1) {
+                        var data1 = data.stages;
+                        if (data1 === undefined) {
+                          valid1 = false;
+                          validate.errors = [{
+                            keyword: 'required',
+                            dataPath: (dataPath || '') + "",
+                            schemaPath: '#/required',
+                            params: {
+                              missingProperty: 'stages'
+                            },
+                            message: 'should have required property \'stages\''
+                          }];
+                          return false;
+                        } else {
+                          var errs_1 = errors;
+                          if (Array.isArray(data1)) {
+                            if (data1.length < 1) {
+                              validate.errors = [{
+                                keyword: 'minItems',
+                                dataPath: (dataPath || '') + '.stages',
+                                schemaPath: '#/properties/stages/minItems',
+                                params: {
+                                  limit: 1
+                                },
+                                message: 'should NOT have fewer than 1 items'
+                              }];
+                              return false;
+                            } else {
+                              var errs__1 = errors;
+                              var valid1;
+                              for (var i1 = 0; i1 < data1.length; i1++) {
+                                var errs_2 = errors;
+                                if (!refVal14(data1[i1], (dataPath || '') + '.stages[' + i1 + ']', data1, i1, rootData)) {
+                                  if (vErrors === null) vErrors = refVal14.errors;
+                                  else vErrors = vErrors.concat(refVal14.errors);
+                                  errors = vErrors.length;
+                                }
+                                var valid2 = errors === errs_2;
+                                if (!valid2) break;
+                              }
+                            }
+                          } else {
+                            validate.errors = [{
+                              keyword: 'type',
+                              dataPath: (dataPath || '') + '.stages',
+                              schemaPath: '#/properties/stages/type',
+                              params: {
+                                type: 'array'
+                              },
+                              message: 'should be array'
+                            }];
+                            return false;
+                          }
+                          var valid1 = errors === errs_1;
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal1.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "lastModified": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "schemaVersion": {
+        "type": "string"
+      },
+      "codebook": {
+        "$ref": "#/definitions/codebook"
+      },
+      "assetManifest": {
+        "$ref": "#/definitions/AssetManifest"
+      },
+      "stages": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Stage"
+        },
+        "minItems": 1
+      }
+    },
+    "required": ["name", "stages", "codebook"],
+    "title": "Protocol"
+  };
+  refVal1.errors = null;
+  refVal[1] = refVal1;
+  var refVal2 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'node' || key0 == 'edge' || key0 == 'ego');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            if (data.node === undefined) {
+              valid1 = true;
+            } else {
+              var errs_1 = errors;
+              if (!refVal3(data.node, (dataPath || '') + '.node', data, 'node', rootData)) {
+                if (vErrors === null) vErrors = refVal3.errors;
+                else vErrors = vErrors.concat(refVal3.errors);
+                errors = vErrors.length;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              if (data.edge === undefined) {
+                valid1 = true;
+              } else {
+                var errs_1 = errors;
+                if (!refVal10(data.edge, (dataPath || '') + '.edge', data, 'edge', rootData)) {
+                  if (vErrors === null) vErrors = refVal10.errors;
+                  else vErrors = vErrors.concat(refVal10.errors);
+                  errors = vErrors.length;
+                }
+                var valid1 = errors === errs_1;
+              }
+              if (valid1) {
+                if (data.ego === undefined) {
+                  valid1 = true;
+                } else {
+                  var errs_1 = errors;
+                  if (!refVal12(data.ego, (dataPath || '') + '.ego', data, 'ego', rootData)) {
+                    if (vErrors === null) vErrors = refVal12.errors;
+                    else vErrors = vErrors.concat(refVal12.errors);
+                    errors = vErrors.length;
+                  }
+                  var valid1 = errors === errs_1;
+                }
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal2.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "node": {
+        "$ref": "#/definitions/Node"
+      },
+      "edge": {
+        "$ref": "#/definitions/Edge"
+      },
+      "ego": {
+        "$ref": "#/definitions/Ego"
+      }
+    },
+    "required": [],
+    "title": "codebook"
+  };
+  refVal2.errors = null;
+  refVal[2] = refVal2;
+  var refVal3 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        var errs__0 = errors;
+        var valid1 = true;
+        for (var key0 in data) {
+          var isAdditional0 = !(false || pattern0.test(key0));
+          if (isAdditional0) {
+            valid1 = false;
+            validate.errors = [{
+              keyword: 'additionalProperties',
+              dataPath: (dataPath || '') + "",
+              schemaPath: '#/additionalProperties',
+              params: {
+                additionalProperty: '' + key0 + ''
+              },
+              message: 'should NOT have additional properties'
+            }];
+            return false;
+            break;
+          }
+        }
+        if (valid1) {
+          for (var key0 in data) {
+            if (pattern0.test(key0)) {
+              var errs_1 = errors;
+              if (!refVal4(data[key0], (dataPath || '') + '[\'' + key0 + '\']', data, key0, rootData)) {
+                if (vErrors === null) vErrors = refVal4.errors;
+                else vErrors = vErrors.concat(refVal4.errors);
+                errors = vErrors.length;
+              }
+              var valid1 = errors === errs_1;
+              if (!valid1) break;
+            } else valid1 = true;
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal3.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "title": "Node",
+    "patternProperties": {
+      ".+": {
+        "$ref": "#/definitions/NodeTypeDef"
+      }
+    }
+  };
+  refVal3.errors = null;
+  refVal[3] = refVal3;
+  var refVal4 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'name' || key0 == 'displayVariable' || key0 == 'iconVariant' || key0 == 'variables' || key0 == 'color');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            if (data.name === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'name'
+                },
+                message: 'should have required property \'name\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              if (typeof data.name !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.name',
+                  schemaPath: '#/properties/name/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              if (data.displayVariable === undefined) {
+                valid1 = true;
+              } else {
+                var errs_1 = errors;
+                if (typeof data.displayVariable !== "string") {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.displayVariable',
+                    schemaPath: '#/properties/displayVariable/type',
+                    params: {
+                      type: 'string'
+                    },
+                    message: 'should be string'
+                  }];
+                  return false;
+                }
+                var valid1 = errors === errs_1;
+              }
+              if (valid1) {
+                if (data.iconVariant === undefined) {
+                  valid1 = true;
+                } else {
+                  var errs_1 = errors;
+                  if (typeof data.iconVariant !== "string") {
+                    validate.errors = [{
+                      keyword: 'type',
+                      dataPath: (dataPath || '') + '.iconVariant',
+                      schemaPath: '#/properties/iconVariant/type',
+                      params: {
+                        type: 'string'
+                      },
+                      message: 'should be string'
+                    }];
+                    return false;
+                  }
+                  var valid1 = errors === errs_1;
+                }
+                if (valid1) {
+                  if (data.variables === undefined) {
+                    valid1 = false;
+                    validate.errors = [{
+                      keyword: 'required',
+                      dataPath: (dataPath || '') + "",
+                      schemaPath: '#/required',
+                      params: {
+                        missingProperty: 'variables'
+                      },
+                      message: 'should have required property \'variables\''
+                    }];
+                    return false;
+                  } else {
+                    var errs_1 = errors;
+                    if (!refVal5(data.variables, (dataPath || '') + '.variables', data, 'variables', rootData)) {
+                      if (vErrors === null) vErrors = refVal5.errors;
+                      else vErrors = vErrors.concat(refVal5.errors);
+                      errors = vErrors.length;
+                    }
+                    var valid1 = errors === errs_1;
+                  }
+                  if (valid1) {
+                    if (data.color === undefined) {
+                      valid1 = false;
+                      validate.errors = [{
+                        keyword: 'required',
+                        dataPath: (dataPath || '') + "",
+                        schemaPath: '#/required',
+                        params: {
+                          missingProperty: 'color'
+                        },
+                        message: 'should have required property \'color\''
+                      }];
+                      return false;
+                    } else {
+                      var errs_1 = errors;
+                      if (typeof data.color !== "string") {
+                        validate.errors = [{
+                          keyword: 'type',
+                          dataPath: (dataPath || '') + '.color',
+                          schemaPath: '#/properties/color/type',
+                          params: {
+                            type: 'string'
+                          },
+                          message: 'should be string'
+                        }];
+                        return false;
+                      }
+                      var valid1 = errors === errs_1;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal4.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "displayVariable": {
+        "type": "string"
+      },
+      "iconVariant": {
+        "type": "string"
+      },
+      "variables": {
+        "$ref": "#/definitions/Variables"
+      },
+      "color": {
+        "type": "string"
+      }
+    },
+    "required": ["name", "variables", "color"],
+    "title": "NodeTypeDef"
+  };
+  refVal4.errors = null;
+  refVal[4] = refVal4;
+  var refVal5 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        var errs__0 = errors;
+        var valid1 = true;
+        for (var key0 in data) {
+          var isAdditional0 = !(false || pattern0.test(key0));
+          if (isAdditional0) {
+            valid1 = false;
+            validate.errors = [{
+              keyword: 'additionalProperties',
+              dataPath: (dataPath || '') + "",
+              schemaPath: '#/additionalProperties',
+              params: {
+                additionalProperty: '' + key0 + ''
+              },
+              message: 'should NOT have additional properties'
+            }];
+            return false;
+            break;
+          }
+        }
+        if (valid1) {
+          for (var key0 in data) {
+            if (pattern0.test(key0)) {
+              var errs_1 = errors;
+              if (!refVal6(data[key0], (dataPath || '') + '[\'' + key0 + '\']', data, key0, rootData)) {
+                if (vErrors === null) vErrors = refVal6.errors;
+                else vErrors = vErrors.concat(refVal6.errors);
+                errors = vErrors.length;
+              }
+              var valid1 = errors === errs_1;
+              if (!valid1) break;
+            } else valid1 = true;
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal5.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "title": "Variables",
+    "patternProperties": {
+      ".+": {
+        "$ref": "#/definitions/Variable"
+      }
+    }
+  };
+  refVal5.errors = null;
+  refVal[5] = refVal5;
+  var refVal6 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'name' || key0 == 'type' || key0 == 'options');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            if (data.name === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'name'
+                },
+                message: 'should have required property \'name\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              if (typeof data.name !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.name',
+                  schemaPath: '#/properties/name/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              var data1 = data.type;
+              if (data1 === undefined) {
+                valid1 = false;
+                validate.errors = [{
+                  keyword: 'required',
+                  dataPath: (dataPath || '') + "",
+                  schemaPath: '#/required',
+                  params: {
+                    missingProperty: 'type'
+                  },
+                  message: 'should have required property \'type\''
+                }];
+                return false;
+              } else {
+                var errs_1 = errors;
+                if (typeof data1 !== "string") {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.type',
+                    schemaPath: '#/properties/type/type',
+                    params: {
+                      type: 'string'
+                    },
+                    message: 'should be string'
+                  }];
+                  return false;
+                }
+                var schema1 = validate.schema.properties.type.enum;
+                var valid1;
+                valid1 = false;
+                for (var i1 = 0; i1 < schema1.length; i1++)
+                  if (equal(data1, schema1[i1])) {
+                    valid1 = true;
+                    break;
+                  } if (!valid1) {
+                  validate.errors = [{
+                    keyword: 'enum',
+                    dataPath: (dataPath || '') + '.type',
+                    schemaPath: '#/properties/type/enum',
+                    params: {
+                      allowedValues: schema1
+                    },
+                    message: 'should be equal to one of the allowed values'
+                  }];
+                  return false;
+                }
+                var valid1 = errors === errs_1;
+              }
+              if (valid1) {
+                var data1 = data.options;
+                if (data1 === undefined) {
+                  valid1 = true;
+                } else {
+                  var errs_1 = errors;
+                  if (Array.isArray(data1)) {
+                    var errs__1 = errors;
+                    var valid1;
+                    for (var i1 = 0; i1 < data1.length; i1++) {
+                      var errs_2 = errors;
+                      if (!refVal7(data1[i1], (dataPath || '') + '.options[' + i1 + ']', data1, i1, rootData)) {
+                        if (vErrors === null) vErrors = refVal7.errors;
+                        else vErrors = vErrors.concat(refVal7.errors);
+                        errors = vErrors.length;
+                      }
+                      var valid2 = errors === errs_2;
+                      if (!valid2) break;
+                    }
+                  } else {
+                    validate.errors = [{
+                      keyword: 'type',
+                      dataPath: (dataPath || '') + '.options',
+                      schemaPath: '#/properties/options/type',
+                      params: {
+                        type: 'array'
+                      },
+                      message: 'should be array'
+                    }];
+                    return false;
+                  }
+                  var valid1 = errors === errs_1;
+                }
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal6.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "type": {
+        "type": "string",
+        "enum": ["boolean", "text", "number", "datetime", "ordinal", "categorical", "layout", "location"]
+      },
+      "options": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/OptionElement"
+        }
+      }
+    },
+    "required": ["type", "name"],
+    "title": "Variable"
+  };
+  refVal6.errors = null;
+  refVal[6] = refVal6;
+  var refVal7 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      var errs__0 = errors;
+      var valid0 = false;
+      var errs_1 = errors;
+      if (!refVal8(data, (dataPath || ''), parentData, parentDataProperty, rootData)) {
+        if (vErrors === null) vErrors = refVal8.errors;
+        else vErrors = vErrors.concat(refVal8.errors);
+        errors = vErrors.length;
+      }
+      var valid1 = errors === errs_1;
+      valid0 = valid0 || valid1;
+      if (!valid0) {
+        var errs_1 = errors;
+        if ((typeof data !== "number" || (data % 1) || data !== data)) {
+          var err = {
+            keyword: 'type',
+            dataPath: (dataPath || '') + "",
+            schemaPath: '#/anyOf/1/type',
+            params: {
+              type: 'integer'
+            },
+            message: 'should be integer'
+          };
+          if (vErrors === null) vErrors = [err];
+          else vErrors.push(err);
+          errors++;
+        }
+        var valid1 = errors === errs_1;
+        valid0 = valid0 || valid1;
+        if (!valid0) {
+          var errs_1 = errors;
+          if (typeof data !== "string") {
+            var err = {
+              keyword: 'type',
+              dataPath: (dataPath || '') + "",
+              schemaPath: '#/anyOf/2/type',
+              params: {
+                type: 'string'
+              },
+              message: 'should be string'
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
+          }
+          var valid1 = errors === errs_1;
+          valid0 = valid0 || valid1;
+        }
+      }
+      if (!valid0) {
+        var err = {
+          keyword: 'anyOf',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/anyOf',
+          params: {},
+          message: 'should match some schema in anyOf'
+        };
+        if (vErrors === null) vErrors = [err];
+        else vErrors.push(err);
+        errors++;
+        validate.errors = vErrors;
+        return false;
+      } else {
+        errors = errs__0;
+        if (vErrors !== null) {
+          if (errs__0) vErrors.length = errs__0;
+          else vErrors = null;
+        }
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal7.schema = {
+    "anyOf": [{
+      "$ref": "#/definitions/OptionClass"
+    }, {
+      "type": "integer"
+    }, {
+      "type": "string"
+    }],
+    "title": "Variable Option"
+  };
+  refVal7.errors = null;
+  refVal[7] = refVal7;
+  var refVal8 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'label' || key0 == 'value');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            if (data.label === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'label'
+                },
+                message: 'should have required property \'label\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              if (typeof data.label !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.label',
+                  schemaPath: '#/properties/label/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              var data1 = data.value;
+              if (data1 === undefined) {
+                valid1 = false;
+                validate.errors = [{
+                  keyword: 'required',
+                  dataPath: (dataPath || '') + "",
+                  schemaPath: '#/required',
+                  params: {
+                    missingProperty: 'value'
+                  },
+                  message: 'should have required property \'value\''
+                }];
+                return false;
+              } else {
+                var errs_1 = errors;
+                var errs_2 = errors;
+                var errs__2 = errors;
+                var valid2 = false;
+                var errs_3 = errors;
+                if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
+                  var err = {
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.value',
+                    schemaPath: '#/definitions/Value/anyOf/0/type',
+                    params: {
+                      type: 'integer'
+                    },
+                    message: 'should be integer'
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid3 = errors === errs_3;
+                valid2 = valid2 || valid3;
+                if (!valid2) {
+                  var errs_3 = errors;
+                  if (typeof data1 !== "string") {
+                    var err = {
+                      keyword: 'type',
+                      dataPath: (dataPath || '') + '.value',
+                      schemaPath: '#/definitions/Value/anyOf/1/type',
+                      params: {
+                        type: 'string'
+                      },
+                      message: 'should be string'
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid3 = errors === errs_3;
+                  valid2 = valid2 || valid3;
+                }
+                if (!valid2) {
+                  var err = {
+                    keyword: 'anyOf',
+                    dataPath: (dataPath || '') + '.value',
+                    schemaPath: '#/definitions/Value/anyOf',
+                    params: {},
+                    message: 'should match some schema in anyOf'
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                  validate.errors = vErrors;
+                  return false;
+                } else {
+                  errors = errs__2;
+                  if (vErrors !== null) {
+                    if (errs__2) vErrors.length = errs__2;
+                    else vErrors = null;
+                  }
+                }
+                var valid2 = errors === errs_2;
+                var valid1 = errors === errs_1;
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal8.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "label": {
+        "type": "string"
+      },
+      "value": {
+        "$ref": "#/definitions/Value"
+      }
+    },
+    "required": ["label", "value"],
+    "title": "OptionClass"
+  };
+  refVal8.errors = null;
+  refVal[8] = refVal8;
+  var refVal9 = {
+    "anyOf": [{
+      "type": "integer"
+    }, {
+      "type": "string"
+    }],
+    "title": "Value"
+  };
+  refVal[9] = refVal9;
+  var refVal10 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        var errs__0 = errors;
+        var valid1 = true;
+        for (var key0 in data) {
+          var isAdditional0 = !(false || pattern0.test(key0));
+          if (isAdditional0) {
+            valid1 = false;
+            validate.errors = [{
+              keyword: 'additionalProperties',
+              dataPath: (dataPath || '') + "",
+              schemaPath: '#/additionalProperties',
+              params: {
+                additionalProperty: '' + key0 + ''
+              },
+              message: 'should NOT have additional properties'
+            }];
+            return false;
+            break;
+          }
+        }
+        if (valid1) {
+          for (var key0 in data) {
+            if (pattern0.test(key0)) {
+              var errs_1 = errors;
+              if (!refVal11(data[key0], (dataPath || '') + '[\'' + key0 + '\']', data, key0, rootData)) {
+                if (vErrors === null) vErrors = refVal11.errors;
+                else vErrors = vErrors.concat(refVal11.errors);
+                errors = vErrors.length;
+              }
+              var valid1 = errors === errs_1;
+              if (!valid1) break;
+            } else valid1 = true;
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal10.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "title": "Edge",
+    "patternProperties": {
+      ".+": {
+        "$ref": "#/definitions/EdgeTypeDef"
+      }
+    }
+  };
+  refVal10.errors = null;
+  refVal[10] = refVal10;
+  var refVal11 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'name' || key0 == 'color' || key0 == 'variables');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            if (data.name === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'name'
+                },
+                message: 'should have required property \'name\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              if (typeof data.name !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.name',
+                  schemaPath: '#/properties/name/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              if (data.color === undefined) {
+                valid1 = false;
+                validate.errors = [{
+                  keyword: 'required',
+                  dataPath: (dataPath || '') + "",
+                  schemaPath: '#/required',
+                  params: {
+                    missingProperty: 'color'
+                  },
+                  message: 'should have required property \'color\''
+                }];
+                return false;
+              } else {
+                var errs_1 = errors;
+                if (typeof data.color !== "string") {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.color',
+                    schemaPath: '#/properties/color/type',
+                    params: {
+                      type: 'string'
+                    },
+                    message: 'should be string'
+                  }];
+                  return false;
+                }
+                var valid1 = errors === errs_1;
+              }
+              if (valid1) {
+                if (data.variables === undefined) {
+                  valid1 = true;
+                } else {
+                  var errs_1 = errors;
+                  if (!refVal[5](data.variables, (dataPath || '') + '.variables', data, 'variables', rootData)) {
+                    if (vErrors === null) vErrors = refVal[5].errors;
+                    else vErrors = vErrors.concat(refVal[5].errors);
+                    errors = vErrors.length;
+                  }
+                  var valid1 = errors === errs_1;
+                }
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal11.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "color": {
+        "type": "string"
+      },
+      "variables": {
+        "$ref": "#/definitions/Variables"
+      }
+    },
+    "required": ["name", "color"],
+    "title": "EdgeTypeDef"
+  };
+  refVal11.errors = null;
+  refVal[11] = refVal11;
+  var refVal12 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      validate.errors = null;
+      return true;
+    };
+  })();
+  refVal12.schema = {
+    "label": "string",
+    "color": "string",
+    "title": "Ego",
+    "variables": {
+      "$ref": "#/definitions/Variables"
+    }
+  };
+  refVal12.errors = null;
+  refVal[12] = refVal12;
+  var refVal13 = {
+    "type": "object",
+    "title": "AssetManifest"
+  };
+  refVal[13] = refVal13;
+  var refVal14 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || validate.schema.properties.hasOwnProperty(key0));
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            if (data.id === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'id'
+                },
+                message: 'should have required property \'id\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              if (typeof data.id !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.id',
+                  schemaPath: '#/properties/id/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              var data1 = data.type;
+              if (data1 === undefined) {
+                valid1 = false;
+                validate.errors = [{
+                  keyword: 'required',
+                  dataPath: (dataPath || '') + "",
+                  schemaPath: '#/required',
+                  params: {
+                    missingProperty: 'type'
+                  },
+                  message: 'should have required property \'type\''
+                }];
+                return false;
+              } else {
+                var errs_1 = errors;
+                if (typeof data1 !== "string") {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.type',
+                    schemaPath: '#/properties/type/type',
+                    params: {
+                      type: 'string'
+                    },
+                    message: 'should be string'
+                  }];
+                  return false;
+                }
+                var schema1 = validate.schema.properties.type.enum;
+                var valid1;
+                valid1 = false;
+                for (var i1 = 0; i1 < schema1.length; i1++)
+                  if (equal(data1, schema1[i1])) {
+                    valid1 = true;
+                    break;
+                  } if (!valid1) {
+                  validate.errors = [{
+                    keyword: 'enum',
+                    dataPath: (dataPath || '') + '.type',
+                    schemaPath: '#/properties/type/enum',
+                    params: {
+                      allowedValues: schema1
+                    },
+                    message: 'should be equal to one of the allowed values'
+                  }];
+                  return false;
+                }
+                var valid1 = errors === errs_1;
+              }
+              if (valid1) {
+                if (data.label === undefined) {
+                  valid1 = false;
+                  validate.errors = [{
+                    keyword: 'required',
+                    dataPath: (dataPath || '') + "",
+                    schemaPath: '#/required',
+                    params: {
+                      missingProperty: 'label'
+                    },
+                    message: 'should have required property \'label\''
+                  }];
+                  return false;
+                } else {
+                  var errs_1 = errors;
+                  if (typeof data.label !== "string") {
+                    validate.errors = [{
+                      keyword: 'type',
+                      dataPath: (dataPath || '') + '.label',
+                      schemaPath: '#/properties/label/type',
+                      params: {
+                        type: 'string'
+                      },
+                      message: 'should be string'
+                    }];
+                    return false;
+                  }
+                  var valid1 = errors === errs_1;
+                }
+                if (valid1) {
+                  if (data.form === undefined) {
+                    valid1 = true;
+                  } else {
+                    var errs_1 = errors;
+                    if (!refVal15(data.form, (dataPath || '') + '.form', data, 'form', rootData)) {
+                      if (vErrors === null) vErrors = refVal15.errors;
+                      else vErrors = vErrors.concat(refVal15.errors);
+                      errors = vErrors.length;
+                    }
+                    var valid1 = errors === errs_1;
+                  }
+                  if (valid1) {
+                    var data1 = data.quickAdd;
+                    if (data1 === undefined) {
+                      valid1 = true;
+                    } else {
+                      var errs_1 = errors;
+                      if (typeof data1 !== "string" && data1 !== null) {
+                        validate.errors = [{
+                          keyword: 'type',
+                          dataPath: (dataPath || '') + '.quickAdd',
+                          schemaPath: '#/properties/quickAdd/type',
+                          params: {
+                            type: 'string,null'
+                          },
+                          message: 'should be string,null'
+                        }];
+                        return false;
+                      }
+                      var valid1 = errors === errs_1;
+                    }
+                    if (valid1) {
+                      var data1 = data.dataSource;
+                      if (data1 === undefined) {
+                        valid1 = true;
+                      } else {
+                        var errs_1 = errors;
+                        if (typeof data1 !== "string" && data1 !== null) {
+                          validate.errors = [{
+                            keyword: 'type',
+                            dataPath: (dataPath || '') + '.dataSource',
+                            schemaPath: '#/properties/dataSource/type',
+                            params: {
+                              type: 'string,null'
+                            },
+                            message: 'should be string,null'
+                          }];
+                          return false;
+                        }
+                        var valid1 = errors === errs_1;
+                      }
+                      if (valid1) {
+                        if (data.subject === undefined) {
+                          valid1 = true;
+                        } else {
+                          var errs_1 = errors;
+                          if (!refVal18(data.subject, (dataPath || '') + '.subject', data, 'subject', rootData)) {
+                            if (vErrors === null) vErrors = refVal18.errors;
+                            else vErrors = vErrors.concat(refVal18.errors);
+                            errors = vErrors.length;
+                          }
+                          var valid1 = errors === errs_1;
+                        }
+                        if (valid1) {
+                          var data1 = data.panels;
+                          if (data1 === undefined) {
+                            valid1 = true;
+                          } else {
+                            var errs_1 = errors;
+                            if (Array.isArray(data1)) {
+                              var errs__1 = errors;
+                              var valid1;
+                              for (var i1 = 0; i1 < data1.length; i1++) {
+                                var errs_2 = errors;
+                                if (!refVal20(data1[i1], (dataPath || '') + '.panels[' + i1 + ']', data1, i1, rootData)) {
+                                  if (vErrors === null) vErrors = refVal20.errors;
+                                  else vErrors = vErrors.concat(refVal20.errors);
+                                  errors = vErrors.length;
+                                }
+                                var valid2 = errors === errs_2;
+                                if (!valid2) break;
+                              }
+                            } else {
+                              validate.errors = [{
+                                keyword: 'type',
+                                dataPath: (dataPath || '') + '.panels',
+                                schemaPath: '#/properties/panels/type',
+                                params: {
+                                  type: 'array'
+                                },
+                                message: 'should be array'
+                              }];
+                              return false;
+                            }
+                            var valid1 = errors === errs_1;
+                          }
+                          if (valid1) {
+                            var data1 = data.prompts;
+                            if (data1 === undefined) {
+                              valid1 = true;
+                            } else {
+                              var errs_1 = errors;
+                              if (Array.isArray(data1)) {
+                                if (data1.length < 1) {
+                                  validate.errors = [{
+                                    keyword: 'minItems',
+                                    dataPath: (dataPath || '') + '.prompts',
+                                    schemaPath: '#/properties/prompts/minItems',
+                                    params: {
+                                      limit: 1
+                                    },
+                                    message: 'should NOT have fewer than 1 items'
+                                  }];
+                                  return false;
+                                } else {
+                                  var errs__1 = errors;
+                                  var valid1;
+                                  for (var i1 = 0; i1 < data1.length; i1++) {
+                                    var errs_2 = errors;
+                                    if (!refVal24(data1[i1], (dataPath || '') + '.prompts[' + i1 + ']', data1, i1, rootData)) {
+                                      if (vErrors === null) vErrors = refVal24.errors;
+                                      else vErrors = vErrors.concat(refVal24.errors);
+                                      errors = vErrors.length;
+                                    }
+                                    var valid2 = errors === errs_2;
+                                    if (!valid2) break;
+                                  }
+                                }
+                              } else {
+                                validate.errors = [{
+                                  keyword: 'type',
+                                  dataPath: (dataPath || '') + '.prompts',
+                                  schemaPath: '#/properties/prompts/type',
+                                  params: {
+                                    type: 'array'
+                                  },
+                                  message: 'should be array'
+                                }];
+                                return false;
+                              }
+                              var valid1 = errors === errs_1;
+                            }
+                            if (valid1) {
+                              var data1 = data.presets;
+                              if (data1 === undefined) {
+                                valid1 = true;
+                              } else {
+                                var errs_1 = errors;
+                                if (Array.isArray(data1)) {
+                                  if (data1.length < 1) {
+                                    validate.errors = [{
+                                      keyword: 'minItems',
+                                      dataPath: (dataPath || '') + '.presets',
+                                      schemaPath: '#/properties/presets/minItems',
+                                      params: {
+                                        limit: 1
+                                      },
+                                      message: 'should NOT have fewer than 1 items'
+                                    }];
+                                    return false;
+                                  } else {
+                                    var errs__1 = errors;
+                                    var valid1;
+                                    for (var i1 = 0; i1 < data1.length; i1++) {
+                                      var errs_2 = errors;
+                                      if (!refVal32(data1[i1], (dataPath || '') + '.presets[' + i1 + ']', data1, i1, rootData)) {
+                                        if (vErrors === null) vErrors = refVal32.errors;
+                                        else vErrors = vErrors.concat(refVal32.errors);
+                                        errors = vErrors.length;
+                                      }
+                                      var valid2 = errors === errs_2;
+                                      if (!valid2) break;
+                                    }
+                                  }
+                                } else {
+                                  validate.errors = [{
+                                    keyword: 'type',
+                                    dataPath: (dataPath || '') + '.presets',
+                                    schemaPath: '#/properties/presets/type',
+                                    params: {
+                                      type: 'array'
+                                    },
+                                    message: 'should be array'
+                                  }];
+                                  return false;
+                                }
+                                var valid1 = errors === errs_1;
+                              }
+                              if (valid1) {
+                                var data1 = data.background;
+                                if (data1 === undefined) {
+                                  valid1 = true;
+                                } else {
+                                  var errs_1 = errors;
+                                  if ((!data1 || typeof data1 !== "object" || Array.isArray(data1))) {
+                                    validate.errors = [{
+                                      keyword: 'type',
+                                      dataPath: (dataPath || '') + '.background',
+                                      schemaPath: '#/properties/background/type',
+                                      params: {
+                                        type: 'object'
+                                      },
+                                      message: 'should be object'
+                                    }];
+                                    return false;
+                                  }
+                                  if (Array.isArray(data1)) {
+                                    if (data1.length < 1) {
+                                      validate.errors = [{
+                                        keyword: 'minItems',
+                                        dataPath: (dataPath || '') + '.background',
+                                        schemaPath: '#/properties/background/minItems',
+                                        params: {
+                                          limit: 1
+                                        },
+                                        message: 'should NOT have fewer than 1 items'
+                                      }];
+                                      return false;
+                                    } else {
+                                      var errs__1 = errors;
+                                      var valid1;
+                                      for (var i1 = 0; i1 < data1.length; i1++) {
+                                        var data2 = data1[i1];
+                                        var errs_2 = errors;
+                                        var errs_3 = errors;
+                                        if ((data2 && typeof data2 === "object" && !Array.isArray(data2))) {
+                                          if (true) {
+                                            var errs__3 = errors;
+                                            var valid4 = true;
+                                            for (var key3 in data2) {
+                                              var isAdditional3 = !(false || key3 == 'image' || key3 == 'concentricCircles' || key3 == 'skewedTowardCenter');
+                                              if (isAdditional3) {
+                                                valid4 = false;
+                                                validate.errors = [{
+                                                  keyword: 'additionalProperties',
+                                                  dataPath: (dataPath || '') + '.background[' + i1 + ']',
+                                                  schemaPath: '#/definitions/Background/additionalProperties',
+                                                  params: {
+                                                    additionalProperty: '' + key3 + ''
+                                                  },
+                                                  message: 'should NOT have additional properties'
+                                                }];
+                                                return false;
+                                                break;
+                                              }
+                                            }
+                                            if (valid4) {
+                                              if (data2.image === undefined) {
+                                                valid4 = true;
+                                              } else {
+                                                var errs_4 = errors;
+                                                if (typeof data2.image !== "string") {
+                                                  validate.errors = [{
+                                                    keyword: 'type',
+                                                    dataPath: (dataPath || '') + '.background[' + i1 + '].image',
+                                                    schemaPath: '#/definitions/Background/properties/image/type',
+                                                    params: {
+                                                      type: 'string'
+                                                    },
+                                                    message: 'should be string'
+                                                  }];
+                                                  return false;
+                                                }
+                                                var valid4 = errors === errs_4;
+                                              }
+                                              if (valid4) {
+                                                var data3 = data2.concentricCircles;
+                                                if (data3 === undefined) {
+                                                  valid4 = false;
+                                                  validate.errors = [{
+                                                    keyword: 'required',
+                                                    dataPath: (dataPath || '') + '.background[' + i1 + ']',
+                                                    schemaPath: '#/definitions/Background/required',
+                                                    params: {
+                                                      missingProperty: 'concentricCircles'
+                                                    },
+                                                    message: 'should have required property \'concentricCircles\''
+                                                  }];
+                                                  return false;
+                                                } else {
+                                                  var errs_4 = errors;
+                                                  if ((typeof data3 !== "number" || (data3 % 1) || data3 !== data3)) {
+                                                    validate.errors = [{
+                                                      keyword: 'type',
+                                                      dataPath: (dataPath || '') + '.background[' + i1 + '].concentricCircles',
+                                                      schemaPath: '#/definitions/Background/properties/concentricCircles/type',
+                                                      params: {
+                                                        type: 'integer'
+                                                      },
+                                                      message: 'should be integer'
+                                                    }];
+                                                    return false;
+                                                  }
+                                                  var valid4 = errors === errs_4;
+                                                }
+                                                if (valid4) {
+                                                  if (data2.skewedTowardCenter === undefined) {
+                                                    valid4 = false;
+                                                    validate.errors = [{
+                                                      keyword: 'required',
+                                                      dataPath: (dataPath || '') + '.background[' + i1 + ']',
+                                                      schemaPath: '#/definitions/Background/required',
+                                                      params: {
+                                                        missingProperty: 'skewedTowardCenter'
+                                                      },
+                                                      message: 'should have required property \'skewedTowardCenter\''
+                                                    }];
+                                                    return false;
+                                                  } else {
+                                                    var errs_4 = errors;
+                                                    if (typeof data2.skewedTowardCenter !== "boolean") {
+                                                      validate.errors = [{
+                                                        keyword: 'type',
+                                                        dataPath: (dataPath || '') + '.background[' + i1 + '].skewedTowardCenter',
+                                                        schemaPath: '#/definitions/Background/properties/skewedTowardCenter/type',
+                                                        params: {
+                                                          type: 'boolean'
+                                                        },
+                                                        message: 'should be boolean'
+                                                      }];
+                                                      return false;
+                                                    }
+                                                    var valid4 = errors === errs_4;
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        } else {
+                                          validate.errors = [{
+                                            keyword: 'type',
+                                            dataPath: (dataPath || '') + '.background[' + i1 + ']',
+                                            schemaPath: '#/definitions/Background/type',
+                                            params: {
+                                              type: 'object'
+                                            },
+                                            message: 'should be object'
+                                          }];
+                                          return false;
+                                        }
+                                        var valid3 = errors === errs_3;
+                                        var valid2 = errors === errs_2;
+                                        if (!valid2) break;
+                                      }
+                                    }
+                                  }
+                                  var valid1 = errors === errs_1;
+                                }
+                                if (valid1) {
+                                  var data1 = data.sortOptions;
+                                  if (data1 === undefined) {
+                                    valid1 = true;
+                                  } else {
+                                    var errs_1 = errors;
+                                    if ((!data1 || typeof data1 !== "object" || Array.isArray(data1))) {
+                                      validate.errors = [{
+                                        keyword: 'type',
+                                        dataPath: (dataPath || '') + '.sortOptions',
+                                        schemaPath: '#/properties/sortOptions/type',
+                                        params: {
+                                          type: 'object'
+                                        },
+                                        message: 'should be object'
+                                      }];
+                                      return false;
+                                    }
+                                    if (Array.isArray(data1)) {
+                                      var errs__1 = errors;
+                                      var valid1;
+                                      for (var i1 = 0; i1 < data1.length; i1++) {
+                                        var errs_2 = errors;
+                                        if (!refVal35(data1[i1], (dataPath || '') + '.sortOptions[' + i1 + ']', data1, i1, rootData)) {
+                                          if (vErrors === null) vErrors = refVal35.errors;
+                                          else vErrors = vErrors.concat(refVal35.errors);
+                                          errors = vErrors.length;
+                                        }
+                                        var valid2 = errors === errs_2;
+                                        if (!valid2) break;
+                                      }
+                                    }
+                                    var valid1 = errors === errs_1;
+                                  }
+                                  if (valid1) {
+                                    var data1 = data.cardOptions;
+                                    if (data1 === undefined) {
+                                      valid1 = true;
+                                    } else {
+                                      var errs_1 = errors;
+                                      if ((!data1 || typeof data1 !== "object" || Array.isArray(data1))) {
+                                        validate.errors = [{
+                                          keyword: 'type',
+                                          dataPath: (dataPath || '') + '.cardOptions',
+                                          schemaPath: '#/properties/cardOptions/type',
+                                          params: {
+                                            type: 'object'
+                                          },
+                                          message: 'should be object'
+                                        }];
+                                        return false;
+                                      }
+                                      if (Array.isArray(data1)) {
+                                        var errs__1 = errors;
+                                        var valid1;
+                                        for (var i1 = 0; i1 < data1.length; i1++) {
+                                          var errs_2 = errors;
+                                          if (!refVal37(data1[i1], (dataPath || '') + '.cardOptions[' + i1 + ']', data1, i1, rootData)) {
+                                            if (vErrors === null) vErrors = refVal37.errors;
+                                            else vErrors = vErrors.concat(refVal37.errors);
+                                            errors = vErrors.length;
+                                          }
+                                          var valid2 = errors === errs_2;
+                                          if (!valid2) break;
+                                        }
+                                      }
+                                      var valid1 = errors === errs_1;
+                                    }
+                                    if (valid1) {
+                                      var data1 = data.searchOptions;
+                                      if (data1 === undefined) {
+                                        valid1 = true;
+                                      } else {
+                                        var errs_1 = errors;
+                                        if ((!data1 || typeof data1 !== "object" || Array.isArray(data1))) {
+                                          validate.errors = [{
+                                            keyword: 'type',
+                                            dataPath: (dataPath || '') + '.searchOptions',
+                                            schemaPath: '#/properties/searchOptions/type',
+                                            params: {
+                                              type: 'object'
+                                            },
+                                            message: 'should be object'
+                                          }];
+                                          return false;
+                                        }
+                                        if (Array.isArray(data1)) {
+                                          var errs__1 = errors;
+                                          var valid1;
+                                          for (var i1 = 0; i1 < data1.length; i1++) {
+                                            var data2 = data1[i1];
+                                            var errs_2 = errors;
+                                            var errs_3 = errors;
+                                            if ((data2 && typeof data2 === "object" && !Array.isArray(data2))) {
+                                              if (true) {
+                                                var errs__3 = errors;
+                                                var valid4 = true;
+                                                for (var key3 in data2) {
+                                                  var isAdditional3 = !(false || key3 == 'fuzziness' || key3 == 'matchProperties');
+                                                  if (isAdditional3) {
+                                                    valid4 = false;
+                                                    validate.errors = [{
+                                                      keyword: 'additionalProperties',
+                                                      dataPath: (dataPath || '') + '.searchOptions[' + i1 + ']',
+                                                      schemaPath: '#/definitions/SearchOptions/additionalProperties',
+                                                      params: {
+                                                        additionalProperty: '' + key3 + ''
+                                                      },
+                                                      message: 'should NOT have additional properties'
+                                                    }];
+                                                    return false;
+                                                    break;
+                                                  }
+                                                }
+                                                if (valid4) {
+                                                  if (data2.fuzziness === undefined) {
+                                                    valid4 = false;
+                                                    validate.errors = [{
+                                                      keyword: 'required',
+                                                      dataPath: (dataPath || '') + '.searchOptions[' + i1 + ']',
+                                                      schemaPath: '#/definitions/SearchOptions/required',
+                                                      params: {
+                                                        missingProperty: 'fuzziness'
+                                                      },
+                                                      message: 'should have required property \'fuzziness\''
+                                                    }];
+                                                    return false;
+                                                  } else {
+                                                    var errs_4 = errors;
+                                                    if (typeof data2.fuzziness !== "number") {
+                                                      validate.errors = [{
+                                                        keyword: 'type',
+                                                        dataPath: (dataPath || '') + '.searchOptions[' + i1 + '].fuzziness',
+                                                        schemaPath: '#/definitions/SearchOptions/properties/fuzziness/type',
+                                                        params: {
+                                                          type: 'number'
+                                                        },
+                                                        message: 'should be number'
+                                                      }];
+                                                      return false;
+                                                    }
+                                                    var valid4 = errors === errs_4;
+                                                  }
+                                                  if (valid4) {
+                                                    var data3 = data2.matchProperties;
+                                                    if (data3 === undefined) {
+                                                      valid4 = false;
+                                                      validate.errors = [{
+                                                        keyword: 'required',
+                                                        dataPath: (dataPath || '') + '.searchOptions[' + i1 + ']',
+                                                        schemaPath: '#/definitions/SearchOptions/required',
+                                                        params: {
+                                                          missingProperty: 'matchProperties'
+                                                        },
+                                                        message: 'should have required property \'matchProperties\''
+                                                      }];
+                                                      return false;
+                                                    } else {
+                                                      var errs_4 = errors;
+                                                      if (Array.isArray(data3)) {
+                                                        var errs__4 = errors;
+                                                        var valid4;
+                                                        for (var i4 = 0; i4 < data3.length; i4++) {
+                                                          var errs_5 = errors;
+                                                          if (typeof data3[i4] !== "string") {
+                                                            validate.errors = [{
+                                                              keyword: 'type',
+                                                              dataPath: (dataPath || '') + '.searchOptions[' + i1 + '].matchProperties[' + i4 + ']',
+                                                              schemaPath: '#/definitions/SearchOptions/properties/matchProperties/items/type',
+                                                              params: {
+                                                                type: 'string'
+                                                              },
+                                                              message: 'should be string'
+                                                            }];
+                                                            return false;
+                                                          }
+                                                          var valid5 = errors === errs_5;
+                                                          if (!valid5) break;
+                                                        }
+                                                      } else {
+                                                        validate.errors = [{
+                                                          keyword: 'type',
+                                                          dataPath: (dataPath || '') + '.searchOptions[' + i1 + '].matchProperties',
+                                                          schemaPath: '#/definitions/SearchOptions/properties/matchProperties/type',
+                                                          params: {
+                                                            type: 'array'
+                                                          },
+                                                          message: 'should be array'
+                                                        }];
+                                                        return false;
+                                                      }
+                                                      var valid4 = errors === errs_4;
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            } else {
+                                              validate.errors = [{
+                                                keyword: 'type',
+                                                dataPath: (dataPath || '') + '.searchOptions[' + i1 + ']',
+                                                schemaPath: '#/definitions/SearchOptions/type',
+                                                params: {
+                                                  type: 'object'
+                                                },
+                                                message: 'should be object'
+                                              }];
+                                              return false;
+                                            }
+                                            var valid3 = errors === errs_3;
+                                            var valid2 = errors === errs_2;
+                                            if (!valid2) break;
+                                          }
+                                        }
+                                        var valid1 = errors === errs_1;
+                                      }
+                                      if (valid1) {
+                                        var data1 = data.behaviours;
+                                        if (data1 === undefined) {
+                                          valid1 = true;
+                                        } else {
+                                          var errs_1 = errors;
+                                          if ((!data1 || typeof data1 !== "object" || Array.isArray(data1))) {
+                                            validate.errors = [{
+                                              keyword: 'type',
+                                              dataPath: (dataPath || '') + '.behaviours',
+                                              schemaPath: '#/properties/behaviours/type',
+                                              params: {
+                                                type: 'object'
+                                              },
+                                              message: 'should be object'
+                                            }];
+                                            return false;
+                                          }
+                                          if (Array.isArray(data1)) {
+                                            if (data1.length < 1) {
+                                              validate.errors = [{
+                                                keyword: 'minItems',
+                                                dataPath: (dataPath || '') + '.behaviours',
+                                                schemaPath: '#/properties/behaviours/minItems',
+                                                params: {
+                                                  limit: 1
+                                                },
+                                                message: 'should NOT have fewer than 1 items'
+                                              }];
+                                              return false;
+                                            } else {
+                                              var errs__1 = errors;
+                                              var valid1;
+                                              for (var i1 = 0; i1 < data1.length; i1++) {
+                                                var data2 = data1[i1];
+                                                var errs_2 = errors;
+                                                var errs_3 = errors;
+                                                if ((data2 && typeof data2 === "object" && !Array.isArray(data2))) {
+                                                  if (true) {
+                                                    var errs__3 = errors;
+                                                    var valid4 = true;
+                                                    for (var key3 in data2) {
+                                                      var isAdditional3 = !(false || key3 == 'freeDraw' || key3 == 'featureNode' || key3 == 'allowRepositioning');
+                                                      if (isAdditional3) {
+                                                        valid4 = false;
+                                                        validate.errors = [{
+                                                          keyword: 'additionalProperties',
+                                                          dataPath: (dataPath || '') + '.behaviours[' + i1 + ']',
+                                                          schemaPath: '#/definitions/Behaviours/additionalProperties',
+                                                          params: {
+                                                            additionalProperty: '' + key3 + ''
+                                                          },
+                                                          message: 'should NOT have additional properties'
+                                                        }];
+                                                        return false;
+                                                        break;
+                                                      }
+                                                    }
+                                                    if (valid4) {
+                                                      if (data2.freeDraw === undefined) {
+                                                        valid4 = true;
+                                                      } else {
+                                                        var errs_4 = errors;
+                                                        if (typeof data2.freeDraw !== "boolean") {
+                                                          validate.errors = [{
+                                                            keyword: 'type',
+                                                            dataPath: (dataPath || '') + '.behaviours[' + i1 + '].freeDraw',
+                                                            schemaPath: '#/definitions/Behaviours/properties/freeDraw/type',
+                                                            params: {
+                                                              type: 'boolean'
+                                                            },
+                                                            message: 'should be boolean'
+                                                          }];
+                                                          return false;
+                                                        }
+                                                        var valid4 = errors === errs_4;
+                                                      }
+                                                      if (valid4) {
+                                                        if (data2.featureNode === undefined) {
+                                                          valid4 = true;
+                                                        } else {
+                                                          var errs_4 = errors;
+                                                          if (typeof data2.featureNode !== "boolean") {
+                                                            validate.errors = [{
+                                                              keyword: 'type',
+                                                              dataPath: (dataPath || '') + '.behaviours[' + i1 + '].featureNode',
+                                                              schemaPath: '#/definitions/Behaviours/properties/featureNode/type',
+                                                              params: {
+                                                                type: 'boolean'
+                                                              },
+                                                              message: 'should be boolean'
+                                                            }];
+                                                            return false;
+                                                          }
+                                                          var valid4 = errors === errs_4;
+                                                        }
+                                                        if (valid4) {
+                                                          if (data2.allowRepositioning === undefined) {
+                                                            valid4 = true;
+                                                          } else {
+                                                            var errs_4 = errors;
+                                                            if (typeof data2.allowRepositioning !== "boolean") {
+                                                              validate.errors = [{
+                                                                keyword: 'type',
+                                                                dataPath: (dataPath || '') + '.behaviours[' + i1 + '].allowRepositioning',
+                                                                schemaPath: '#/definitions/Behaviours/properties/allowRepositioning/type',
+                                                                params: {
+                                                                  type: 'boolean'
+                                                                },
+                                                                message: 'should be boolean'
+                                                              }];
+                                                              return false;
+                                                            }
+                                                            var valid4 = errors === errs_4;
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                } else {
+                                                  validate.errors = [{
+                                                    keyword: 'type',
+                                                    dataPath: (dataPath || '') + '.behaviours[' + i1 + ']',
+                                                    schemaPath: '#/definitions/Behaviours/type',
+                                                    params: {
+                                                      type: 'object'
+                                                    },
+                                                    message: 'should be object'
+                                                  }];
+                                                  return false;
+                                                }
+                                                var valid3 = errors === errs_3;
+                                                var valid2 = errors === errs_2;
+                                                if (!valid2) break;
+                                              }
+                                            }
+                                          }
+                                          var valid1 = errors === errs_1;
+                                        }
+                                        if (valid1) {
+                                          if (data.showExistingNodes === undefined) {
+                                            valid1 = true;
+                                          } else {
+                                            var errs_1 = errors;
+                                            if (typeof data.showExistingNodes !== "boolean") {
+                                              validate.errors = [{
+                                                keyword: 'type',
+                                                dataPath: (dataPath || '') + '.showExistingNodes',
+                                                schemaPath: '#/properties/showExistingNodes/type',
+                                                params: {
+                                                  type: 'boolean'
+                                                },
+                                                message: 'should be boolean'
+                                              }];
+                                              return false;
+                                            }
+                                            var valid1 = errors === errs_1;
+                                          }
+                                          if (valid1) {
+                                            if (data.title === undefined) {
+                                              valid1 = true;
+                                            } else {
+                                              var errs_1 = errors;
+                                              if (typeof data.title !== "string") {
+                                                validate.errors = [{
+                                                  keyword: 'type',
+                                                  dataPath: (dataPath || '') + '.title',
+                                                  schemaPath: '#/properties/title/type',
+                                                  params: {
+                                                    type: 'string'
+                                                  },
+                                                  message: 'should be string'
+                                                }];
+                                                return false;
+                                              }
+                                              var valid1 = errors === errs_1;
+                                            }
+                                            if (valid1) {
+                                              var data1 = data.items;
+                                              if (data1 === undefined) {
+                                                valid1 = true;
+                                              } else {
+                                                var errs_1 = errors;
+                                                if (Array.isArray(data1)) {
+                                                  var errs__1 = errors;
+                                                  var valid1;
+                                                  for (var i1 = 0; i1 < data1.length; i1++) {
+                                                    var data2 = data1[i1];
+                                                    var errs_2 = errors;
+                                                    var errs_3 = errors;
+                                                    if ((data2 && typeof data2 === "object" && !Array.isArray(data2))) {
+                                                      if (true) {
+                                                        var errs__3 = errors;
+                                                        var valid4 = true;
+                                                        for (var key3 in data2) {
+                                                          var isAdditional3 = !(false || key3 == 'id' || key3 == 'type' || key3 == 'content' || key3 == 'description' || key3 == 'size' || key3 == 'loop');
+                                                          if (isAdditional3) {
+                                                            valid4 = false;
+                                                            validate.errors = [{
+                                                              keyword: 'additionalProperties',
+                                                              dataPath: (dataPath || '') + '.items[' + i1 + ']',
+                                                              schemaPath: '#/definitions/Item/additionalProperties',
+                                                              params: {
+                                                                additionalProperty: '' + key3 + ''
+                                                              },
+                                                              message: 'should NOT have additional properties'
+                                                            }];
+                                                            return false;
+                                                            break;
+                                                          }
+                                                        }
+                                                        if (valid4) {
+                                                          if (data2.id === undefined) {
+                                                            valid4 = false;
+                                                            validate.errors = [{
+                                                              keyword: 'required',
+                                                              dataPath: (dataPath || '') + '.items[' + i1 + ']',
+                                                              schemaPath: '#/definitions/Item/required',
+                                                              params: {
+                                                                missingProperty: 'id'
+                                                              },
+                                                              message: 'should have required property \'id\''
+                                                            }];
+                                                            return false;
+                                                          } else {
+                                                            var errs_4 = errors;
+                                                            if (typeof data2.id !== "string") {
+                                                              validate.errors = [{
+                                                                keyword: 'type',
+                                                                dataPath: (dataPath || '') + '.items[' + i1 + '].id',
+                                                                schemaPath: '#/definitions/Item/properties/id/type',
+                                                                params: {
+                                                                  type: 'string'
+                                                                },
+                                                                message: 'should be string'
+                                                              }];
+                                                              return false;
+                                                            }
+                                                            var valid4 = errors === errs_4;
+                                                          }
+                                                          if (valid4) {
+                                                            var data3 = data2.type;
+                                                            if (data3 === undefined) {
+                                                              valid4 = false;
+                                                              validate.errors = [{
+                                                                keyword: 'required',
+                                                                dataPath: (dataPath || '') + '.items[' + i1 + ']',
+                                                                schemaPath: '#/definitions/Item/required',
+                                                                params: {
+                                                                  missingProperty: 'type'
+                                                                },
+                                                                message: 'should have required property \'type\''
+                                                              }];
+                                                              return false;
+                                                            } else {
+                                                              var errs_4 = errors;
+                                                              if (typeof data3 !== "string") {
+                                                                validate.errors = [{
+                                                                  keyword: 'type',
+                                                                  dataPath: (dataPath || '') + '.items[' + i1 + '].type',
+                                                                  schemaPath: '#/definitions/Item/properties/type/type',
+                                                                  params: {
+                                                                    type: 'string'
+                                                                  },
+                                                                  message: 'should be string'
+                                                                }];
+                                                                return false;
+                                                              }
+                                                              var schema4 = refVal40.properties.type.enum;
+                                                              var valid4;
+                                                              valid4 = false;
+                                                              for (var i4 = 0; i4 < schema4.length; i4++)
+                                                                if (equal(data3, schema4[i4])) {
+                                                                  valid4 = true;
+                                                                  break;
+                                                                } if (!valid4) {
+                                                                validate.errors = [{
+                                                                  keyword: 'enum',
+                                                                  dataPath: (dataPath || '') + '.items[' + i1 + '].type',
+                                                                  schemaPath: '#/definitions/Item/properties/type/enum',
+                                                                  params: {
+                                                                    allowedValues: schema4
+                                                                  },
+                                                                  message: 'should be equal to one of the allowed values'
+                                                                }];
+                                                                return false;
+                                                              }
+                                                              var valid4 = errors === errs_4;
+                                                            }
+                                                            if (valid4) {
+                                                              if (data2.content === undefined) {
+                                                                valid4 = false;
+                                                                validate.errors = [{
+                                                                  keyword: 'required',
+                                                                  dataPath: (dataPath || '') + '.items[' + i1 + ']',
+                                                                  schemaPath: '#/definitions/Item/required',
+                                                                  params: {
+                                                                    missingProperty: 'content'
+                                                                  },
+                                                                  message: 'should have required property \'content\''
+                                                                }];
+                                                                return false;
+                                                              } else {
+                                                                var errs_4 = errors;
+                                                                if (typeof data2.content !== "string") {
+                                                                  validate.errors = [{
+                                                                    keyword: 'type',
+                                                                    dataPath: (dataPath || '') + '.items[' + i1 + '].content',
+                                                                    schemaPath: '#/definitions/Item/properties/content/type',
+                                                                    params: {
+                                                                      type: 'string'
+                                                                    },
+                                                                    message: 'should be string'
+                                                                  }];
+                                                                  return false;
+                                                                }
+                                                                var valid4 = errors === errs_4;
+                                                              }
+                                                              if (valid4) {
+                                                                if (data2.description === undefined) {
+                                                                  valid4 = true;
+                                                                } else {
+                                                                  var errs_4 = errors;
+                                                                  if (typeof data2.description !== "string") {
+                                                                    validate.errors = [{
+                                                                      keyword: 'type',
+                                                                      dataPath: (dataPath || '') + '.items[' + i1 + '].description',
+                                                                      schemaPath: '#/definitions/Item/properties/description/type',
+                                                                      params: {
+                                                                        type: 'string'
+                                                                      },
+                                                                      message: 'should be string'
+                                                                    }];
+                                                                    return false;
+                                                                  }
+                                                                  var valid4 = errors === errs_4;
+                                                                }
+                                                                if (valid4) {
+                                                                  if (data2.size === undefined) {
+                                                                    valid4 = true;
+                                                                  } else {
+                                                                    var errs_4 = errors;
+                                                                    if (typeof data2.size !== "string") {
+                                                                      validate.errors = [{
+                                                                        keyword: 'type',
+                                                                        dataPath: (dataPath || '') + '.items[' + i1 + '].size',
+                                                                        schemaPath: '#/definitions/Item/properties/size/type',
+                                                                        params: {
+                                                                          type: 'string'
+                                                                        },
+                                                                        message: 'should be string'
+                                                                      }];
+                                                                      return false;
+                                                                    }
+                                                                    var valid4 = errors === errs_4;
+                                                                  }
+                                                                  if (valid4) {
+                                                                    if (data2.loop === undefined) {
+                                                                      valid4 = true;
+                                                                    } else {
+                                                                      var errs_4 = errors;
+                                                                      if (typeof data2.loop !== "boolean") {
+                                                                        validate.errors = [{
+                                                                          keyword: 'type',
+                                                                          dataPath: (dataPath || '') + '.items[' + i1 + '].loop',
+                                                                          schemaPath: '#/definitions/Item/properties/loop/type',
+                                                                          params: {
+                                                                            type: 'boolean'
+                                                                          },
+                                                                          message: 'should be boolean'
+                                                                        }];
+                                                                        return false;
+                                                                      }
+                                                                      var valid4 = errors === errs_4;
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    } else {
+                                                      validate.errors = [{
+                                                        keyword: 'type',
+                                                        dataPath: (dataPath || '') + '.items[' + i1 + ']',
+                                                        schemaPath: '#/definitions/Item/type',
+                                                        params: {
+                                                          type: 'object'
+                                                        },
+                                                        message: 'should be object'
+                                                      }];
+                                                      return false;
+                                                    }
+                                                    var valid3 = errors === errs_3;
+                                                    var valid2 = errors === errs_2;
+                                                    if (!valid2) break;
+                                                  }
+                                                } else {
+                                                  validate.errors = [{
+                                                    keyword: 'type',
+                                                    dataPath: (dataPath || '') + '.items',
+                                                    schemaPath: '#/properties/items/type',
+                                                    params: {
+                                                      type: 'array'
+                                                    },
+                                                    message: 'should be array'
+                                                  }];
+                                                  return false;
+                                                }
+                                                var valid1 = errors === errs_1;
+                                              }
+                                              if (valid1) {
+                                                var data1 = data.introductionPanel;
+                                                if (data1 === undefined) {
+                                                  valid1 = true;
+                                                } else {
+                                                  var errs_1 = errors;
+                                                  var errs_2 = errors;
+                                                  if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
+                                                    if (true) {
+                                                      var errs__2 = errors;
+                                                      var valid3 = true;
+                                                      for (var key2 in data1) {
+                                                        var isAdditional2 = !(false || key2 == 'title' || key2 == 'text');
+                                                        if (isAdditional2) {
+                                                          valid3 = false;
+                                                          validate.errors = [{
+                                                            keyword: 'additionalProperties',
+                                                            dataPath: (dataPath || '') + '.introductionPanel',
+                                                            schemaPath: '#/definitions/IntroductionPanel/additionalProperties',
+                                                            params: {
+                                                              additionalProperty: '' + key2 + ''
+                                                            },
+                                                            message: 'should NOT have additional properties'
+                                                          }];
+                                                          return false;
+                                                          break;
+                                                        }
+                                                      }
+                                                      if (valid3) {
+                                                        if (data1.title === undefined) {
+                                                          valid3 = false;
+                                                          validate.errors = [{
+                                                            keyword: 'required',
+                                                            dataPath: (dataPath || '') + '.introductionPanel',
+                                                            schemaPath: '#/definitions/IntroductionPanel/required',
+                                                            params: {
+                                                              missingProperty: 'title'
+                                                            },
+                                                            message: 'should have required property \'title\''
+                                                          }];
+                                                          return false;
+                                                        } else {
+                                                          var errs_3 = errors;
+                                                          if (typeof data1.title !== "string") {
+                                                            validate.errors = [{
+                                                              keyword: 'type',
+                                                              dataPath: (dataPath || '') + '.introductionPanel.title',
+                                                              schemaPath: '#/definitions/IntroductionPanel/properties/title/type',
+                                                              params: {
+                                                                type: 'string'
+                                                              },
+                                                              message: 'should be string'
+                                                            }];
+                                                            return false;
+                                                          }
+                                                          var valid3 = errors === errs_3;
+                                                        }
+                                                        if (valid3) {
+                                                          if (data1.text === undefined) {
+                                                            valid3 = false;
+                                                            validate.errors = [{
+                                                              keyword: 'required',
+                                                              dataPath: (dataPath || '') + '.introductionPanel',
+                                                              schemaPath: '#/definitions/IntroductionPanel/required',
+                                                              params: {
+                                                                missingProperty: 'text'
+                                                              },
+                                                              message: 'should have required property \'text\''
+                                                            }];
+                                                            return false;
+                                                          } else {
+                                                            var errs_3 = errors;
+                                                            if (typeof data1.text !== "string") {
+                                                              validate.errors = [{
+                                                                keyword: 'type',
+                                                                dataPath: (dataPath || '') + '.introductionPanel.text',
+                                                                schemaPath: '#/definitions/IntroductionPanel/properties/text/type',
+                                                                params: {
+                                                                  type: 'string'
+                                                                },
+                                                                message: 'should be string'
+                                                              }];
+                                                              return false;
+                                                            }
+                                                            var valid3 = errors === errs_3;
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  } else {
+                                                    validate.errors = [{
+                                                      keyword: 'type',
+                                                      dataPath: (dataPath || '') + '.introductionPanel',
+                                                      schemaPath: '#/definitions/IntroductionPanel/type',
+                                                      params: {
+                                                        type: 'object'
+                                                      },
+                                                      message: 'should be object'
+                                                    }];
+                                                    return false;
+                                                  }
+                                                  var valid2 = errors === errs_2;
+                                                  var valid1 = errors === errs_1;
+                                                }
+                                                if (valid1) {
+                                                  if (data.skipLogic === undefined) {
+                                                    valid1 = true;
+                                                  } else {
+                                                    var errs_1 = errors;
+                                                    if (!refVal42(data.skipLogic, (dataPath || '') + '.skipLogic', data, 'skipLogic', rootData)) {
+                                                      if (vErrors === null) vErrors = refVal42.errors;
+                                                      else vErrors = vErrors.concat(refVal42.errors);
+                                                      errors = vErrors.length;
+                                                    }
+                                                    var valid1 = errors === errs_1;
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      if (errors === 0) {
+        var errs__0 = errors;
+        var valid0 = false;
+        var errs_1 = errors;
+        if ((data && typeof data === "object" && !Array.isArray(data))) {
+          var missing1;
+          if (((data.form === undefined) && (missing1 = '.form')) || ((data.introductionPanel === undefined) && (missing1 = '.introductionPanel'))) {
+            var err = {
+              keyword: 'required',
+              dataPath: (dataPath || '') + "",
+              schemaPath: '#/anyOf/0/required',
+              params: {
+                missingProperty: '' + missing1 + ''
+              },
+              message: 'should have required property \'' + missing1 + '\''
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
+          } else {
+            var errs__1 = errors;
+            var valid2 = true;
+            if (data.type === undefined) {
+              valid2 = true;
+            } else {
+              var errs_2 = errors;
+              var schema2 = validate.schema.anyOf[0].properties.type.const;
+              var valid2 = equal(data.type, schema2);
+              if (!valid2) {
+                var err = {
+                  keyword: 'const',
+                  dataPath: (dataPath || '') + '.type',
+                  schemaPath: '#/anyOf/0/properties/type/const',
+                  params: {
+                    allowedValue: schema2
+                  },
+                  message: 'should be equal to constant'
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+          }
+        }
+        var valid1 = errors === errs_1;
+        valid0 = valid0 || valid1;
+        if (!valid0) {
+          var errs_1 = errors;
+          if ((data && typeof data === "object" && !Array.isArray(data))) {
+            var missing1;
+            if (((data.form === undefined) && (missing1 = '.form')) || ((data.introductionPanel === undefined) && (missing1 = '.introductionPanel'))) {
+              var err = {
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/anyOf/1/required',
+                params: {
+                  missingProperty: '' + missing1 + ''
+                },
+                message: 'should have required property \'' + missing1 + '\''
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs__1 = errors;
+              var valid2 = true;
+              if (data.type === undefined) {
+                valid2 = true;
+              } else {
+                var errs_2 = errors;
+                var schema2 = validate.schema.anyOf[1].properties.type.const;
+                var valid2 = equal(data.type, schema2);
+                if (!valid2) {
+                  var err = {
+                    keyword: 'const',
+                    dataPath: (dataPath || '') + '.type',
+                    schemaPath: '#/anyOf/1/properties/type/const',
+                    params: {
+                      allowedValue: schema2
+                    },
+                    message: 'should be equal to constant'
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+            }
+          }
+          var valid1 = errors === errs_1;
+          valid0 = valid0 || valid1;
+          if (!valid0) {
+            var errs_1 = errors;
+            if ((data && typeof data === "object" && !Array.isArray(data))) {
+              var missing1;
+              if (((data.form === undefined) && (missing1 = '.form')) || ((data.introductionPanel === undefined) && (missing1 = '.introductionPanel'))) {
+                var err = {
+                  keyword: 'required',
+                  dataPath: (dataPath || '') + "",
+                  schemaPath: '#/anyOf/2/required',
+                  params: {
+                    missingProperty: '' + missing1 + ''
+                  },
+                  message: 'should have required property \'' + missing1 + '\''
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs__1 = errors;
+                var valid2 = true;
+                if (data.type === undefined) {
+                  valid2 = true;
+                } else {
+                  var errs_2 = errors;
+                  var schema2 = validate.schema.anyOf[2].properties.type.const;
+                  var valid2 = equal(data.type, schema2);
+                  if (!valid2) {
+                    var err = {
+                      keyword: 'const',
+                      dataPath: (dataPath || '') + '.type',
+                      schemaPath: '#/anyOf/2/properties/type/const',
+                      params: {
+                        allowedValue: schema2
+                      },
+                      message: 'should be equal to constant'
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid2 = errors === errs_2;
+                }
+              }
+            }
+            var valid1 = errors === errs_1;
+            valid0 = valid0 || valid1;
+            if (!valid0) {
+              var errs_1 = errors;
+              if ((data && typeof data === "object" && !Array.isArray(data))) {
+                var missing1;
+                if (((data.items === undefined) && (missing1 = '.items'))) {
+                  var err = {
+                    keyword: 'required',
+                    dataPath: (dataPath || '') + "",
+                    schemaPath: '#/anyOf/3/required',
+                    params: {
+                      missingProperty: '' + missing1 + ''
+                    },
+                    message: 'should have required property \'' + missing1 + '\''
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                } else {
+                  var errs__1 = errors;
+                  var valid2 = true;
+                  if (data.type === undefined) {
+                    valid2 = true;
+                  } else {
+                    var errs_2 = errors;
+                    var schema2 = validate.schema.anyOf[3].properties.type.const;
+                    var valid2 = equal(data.type, schema2);
+                    if (!valid2) {
+                      var err = {
+                        keyword: 'const',
+                        dataPath: (dataPath || '') + '.type',
+                        schemaPath: '#/anyOf/3/properties/type/const',
+                        params: {
+                          allowedValue: schema2
+                        },
+                        message: 'should be equal to constant'
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                }
+              }
+              var valid1 = errors === errs_1;
+              valid0 = valid0 || valid1;
+              if (!valid0) {
+                var errs_1 = errors;
+                if ((data && typeof data === "object" && !Array.isArray(data))) {
+                  var missing1;
+                  if (((data.presets === undefined) && (missing1 = '.presets')) || ((data.background === undefined) && (missing1 = '.background')) || ((data.behaviours === undefined) && (missing1 = '.behaviours'))) {
+                    var err = {
+                      keyword: 'required',
+                      dataPath: (dataPath || '') + "",
+                      schemaPath: '#/anyOf/4/required',
+                      params: {
+                        missingProperty: '' + missing1 + ''
+                      },
+                      message: 'should have required property \'' + missing1 + '\''
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  } else {
+                    var errs__1 = errors;
+                    var valid2 = true;
+                    if (data.type === undefined) {
+                      valid2 = true;
+                    } else {
+                      var errs_2 = errors;
+                      var schema2 = validate.schema.anyOf[4].properties.type.const;
+                      var valid2 = equal(data.type, schema2);
+                      if (!valid2) {
+                        var err = {
+                          keyword: 'const',
+                          dataPath: (dataPath || '') + '.type',
+                          schemaPath: '#/anyOf/4/properties/type/const',
+                          params: {
+                            allowedValue: schema2
+                          },
+                          message: 'should be equal to constant'
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid2 = errors === errs_2;
+                    }
+                  }
+                }
+                var valid1 = errors === errs_1;
+                valid0 = valid0 || valid1;
+                if (!valid0) {
+                  var errs_1 = errors;
+                  if ((data && typeof data === "object" && !Array.isArray(data))) {
+                    var missing1;
+                    if (((data.prompts === undefined) && (missing1 = '.prompts'))) {
+                      var err = {
+                        keyword: 'required',
+                        dataPath: (dataPath || '') + "",
+                        schemaPath: '#/anyOf/5/required',
+                        params: {
+                          missingProperty: '' + missing1 + ''
+                        },
+                        message: 'should have required property \'' + missing1 + '\''
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    } else {
+                      var errs__1 = errors;
+                      var valid2 = true;
+                      if (data.type === undefined) {
+                        valid2 = true;
+                      } else {
+                        var errs_2 = errors;
+                        var schema2 = validate.schema.anyOf[5].properties.type.enum;
+                        var valid2;
+                        valid2 = false;
+                        for (var i2 = 0; i2 < schema2.length; i2++)
+                          if (equal(data.type, schema2[i2])) {
+                            valid2 = true;
+                            break;
+                          } if (!valid2) {
+                          var err = {
+                            keyword: 'enum',
+                            dataPath: (dataPath || '') + '.type',
+                            schemaPath: '#/anyOf/5/properties/type/enum',
+                            params: {
+                              allowedValues: schema2
+                            },
+                            message: 'should be equal to one of the allowed values'
+                          };
+                          if (vErrors === null) vErrors = [err];
+                          else vErrors.push(err);
+                          errors++;
+                        }
+                        var valid2 = errors === errs_2;
+                      }
+                    }
+                  }
+                  var valid1 = errors === errs_1;
+                  valid0 = valid0 || valid1;
+                }
+              }
+            }
+          }
+        }
+        if (!valid0) {
+          var err = {
+            keyword: 'anyOf',
+            dataPath: (dataPath || '') + "",
+            schemaPath: '#/anyOf',
+            params: {},
+            message: 'should match some schema in anyOf'
+          };
+          if (vErrors === null) vErrors = [err];
+          else vErrors.push(err);
+          errors++;
+          validate.errors = vErrors;
+          return false;
+        } else {
+          errors = errs__0;
+          if (vErrors !== null) {
+            if (errs__0) vErrors.length = errs__0;
+            else vErrors = null;
+          }
+        }
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal14.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "type": {
+        "type": "string",
+        "enum": ["Narrative", "AlterForm", "AlterEdgeForm", "EgoForm", "NameGenerator", "NameGeneratorQuickAdd", "NameGeneratorList", "NameGeneratorAutoComplete", "Sociogram", "Information", "OrdinalBin", "CategoricalBin"]
+      },
+      "label": {
+        "type": "string"
+      },
+      "form": {
+        "$ref": "#/definitions/Form"
+      },
+      "quickAdd": {
+        "type": ["string", "null"]
+      },
+      "dataSource": {
+        "type": ["string", "null"]
+      },
+      "subject": {
+        "$ref": "#/definitions/Subject"
+      },
+      "panels": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Panel"
+        }
+      },
+      "prompts": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Prompt"
+        },
+        "minItems": 1
+      },
+      "presets": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Preset"
+        },
+        "minItems": 1
+      },
+      "background": {
+        "type": "object",
+        "items": {
+          "$ref": "#/definitions/Background"
+        },
+        "minItems": 1
+      },
+      "sortOptions": {
+        "type": "object",
+        "items": {
+          "$ref": "#/definitions/SortOptions"
+        }
+      },
+      "cardOptions": {
+        "type": "object",
+        "items": {
+          "$ref": "#/definitions/CardOptions"
+        }
+      },
+      "searchOptions": {
+        "type": "object",
+        "items": {
+          "$ref": "#/definitions/SearchOptions"
+        }
+      },
+      "behaviours": {
+        "type": "object",
+        "items": {
+          "$ref": "#/definitions/Behaviours"
+        },
+        "minItems": 1
+      },
+      "showExistingNodes": {
+        "type": "boolean"
+      },
+      "title": {
+        "type": "string"
+      },
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Item"
+        }
+      },
+      "introductionPanel": {
+        "$ref": "#/definitions/IntroductionPanel"
+      },
+      "skipLogic": {
+        "$ref": "#/definitions/SkipLogic"
+      }
+    },
+    "required": ["id", "label", "type"],
+    "title": "Interface",
+    "anyOf": [{
+      "properties": {
+        "type": {
+          "const": "EgoForm"
+        }
+      },
+      "required": ["form", "introductionPanel"]
+    }, {
+      "properties": {
+        "type": {
+          "const": "AlterForm"
+        }
+      },
+      "required": ["form", "introductionPanel"]
+    }, {
+      "properties": {
+        "type": {
+          "const": "AlterEdgeForm"
+        }
+      },
+      "required": ["form", "introductionPanel"]
+    }, {
+      "properties": {
+        "type": {
+          "const": "Information"
+        }
+      },
+      "required": ["items"]
+    }, {
+      "properties": {
+        "type": {
+          "const": "Narrative"
+        }
+      },
+      "required": ["presets", "background", "behaviours"]
+    }, {
+      "properties": {
+        "type": {
+          "enum": ["NameGenerator", "NameGeneratorQuickAdd", "NameGeneratorList", "NameGeneratorAutoComplete", "Sociogram", "OrdinalBin", "CategoricalBin"]
+        }
+      },
+      "required": ["prompts"]
+    }]
+  };
+  refVal14.errors = null;
+  refVal[14] = refVal14;
+  var refVal15 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      if ((!data || typeof data !== "object" || Array.isArray(data)) && data !== null) {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object,null'
+          },
+          message: 'should be object,null'
+        }];
+        return false;
+      }
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'title' || key0 == 'fields');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            if (data.title === undefined) {
+              valid1 = true;
+            } else {
+              var errs_1 = errors;
+              if (typeof data.title !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.title',
+                  schemaPath: '#/properties/title/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              var data1 = data.fields;
+              if (data1 === undefined) {
+                valid1 = false;
+                validate.errors = [{
+                  keyword: 'required',
+                  dataPath: (dataPath || '') + "",
+                  schemaPath: '#/required',
+                  params: {
+                    missingProperty: 'fields'
+                  },
+                  message: 'should have required property \'fields\''
+                }];
+                return false;
+              } else {
+                var errs_1 = errors;
+                if (Array.isArray(data1)) {
+                  var errs__1 = errors;
+                  var valid1;
+                  for (var i1 = 0; i1 < data1.length; i1++) {
+                    var errs_2 = errors;
+                    if (!refVal16(data1[i1], (dataPath || '') + '.fields[' + i1 + ']', data1, i1, rootData)) {
+                      if (vErrors === null) vErrors = refVal16.errors;
+                      else vErrors = vErrors.concat(refVal16.errors);
+                      errors = vErrors.length;
+                    }
+                    var valid2 = errors === errs_2;
+                    if (!valid2) break;
+                  }
+                } else {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.fields',
+                    schemaPath: '#/properties/fields/type',
+                    params: {
+                      type: 'array'
+                    },
+                    message: 'should be array'
+                  }];
+                  return false;
+                }
+                var valid1 = errors === errs_1;
+              }
+            }
+          }
+        }
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal15.schema = {
+    "type": ["object", "null"],
+    "additionalProperties": false,
+    "properties": {
+      "title": {
+        "type": "string"
+      },
+      "fields": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Field"
+        }
+      }
+    },
+    "required": ["fields"],
+    "title": "Form"
+  };
+  refVal15.errors = null;
+  refVal[15] = refVal15;
+  var refVal16 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'variable' || key0 == 'component' || key0 == 'prompt' || key0 == 'validation');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            if (data.variable === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'variable'
+                },
+                message: 'should have required property \'variable\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              if (typeof data.variable !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.variable',
+                  schemaPath: '#/properties/variable/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              var data1 = data.component;
+              if (data1 === undefined) {
+                valid1 = false;
+                validate.errors = [{
+                  keyword: 'required',
+                  dataPath: (dataPath || '') + "",
+                  schemaPath: '#/required',
+                  params: {
+                    missingProperty: 'component'
+                  },
+                  message: 'should have required property \'component\''
+                }];
+                return false;
+              } else {
+                var errs_1 = errors;
+                if (typeof data1 !== "string") {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.component',
+                    schemaPath: '#/properties/component/type',
+                    params: {
+                      type: 'string'
+                    },
+                    message: 'should be string'
+                  }];
+                  return false;
+                }
+                var schema1 = validate.schema.properties.component.enum;
+                var valid1;
+                valid1 = false;
+                for (var i1 = 0; i1 < schema1.length; i1++)
+                  if (equal(data1, schema1[i1])) {
+                    valid1 = true;
+                    break;
+                  } if (!valid1) {
+                  validate.errors = [{
+                    keyword: 'enum',
+                    dataPath: (dataPath || '') + '.component',
+                    schemaPath: '#/properties/component/enum',
+                    params: {
+                      allowedValues: schema1
+                    },
+                    message: 'should be equal to one of the allowed values'
+                  }];
+                  return false;
+                }
+                var valid1 = errors === errs_1;
+              }
+              if (valid1) {
+                if (data.prompt === undefined) {
+                  valid1 = false;
+                  validate.errors = [{
+                    keyword: 'required',
+                    dataPath: (dataPath || '') + "",
+                    schemaPath: '#/required',
+                    params: {
+                      missingProperty: 'prompt'
+                    },
+                    message: 'should have required property \'prompt\''
+                  }];
+                  return false;
+                } else {
+                  var errs_1 = errors;
+                  if (typeof data.prompt !== "string") {
+                    validate.errors = [{
+                      keyword: 'type',
+                      dataPath: (dataPath || '') + '.prompt',
+                      schemaPath: '#/properties/prompt/type',
+                      params: {
+                        type: 'string'
+                      },
+                      message: 'should be string'
+                    }];
+                    return false;
+                  }
+                  var valid1 = errors === errs_1;
+                }
+                if (valid1) {
+                  var data1 = data.validation;
+                  if (data1 === undefined) {
+                    valid1 = true;
+                  } else {
+                    var errs_1 = errors;
+                    var errs_2 = errors;
+                    if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
+                      var errs__2 = errors;
+                      var valid3 = true;
+                      for (var key2 in data1) {
+                        var isAdditional2 = !(false || key2 == 'required' || key2 == 'requiredAcceptsNull' || key2 == 'minLength' || key2 == 'maxLength' || key2 == 'minValue' || key2 == 'maxValue' || key2 == 'minSelected' || key2 == 'maxSelected');
+                        if (isAdditional2) {
+                          valid3 = false;
+                          validate.errors = [{
+                            keyword: 'additionalProperties',
+                            dataPath: (dataPath || '') + '.validation',
+                            schemaPath: '#/definitions/Validation/additionalProperties',
+                            params: {
+                              additionalProperty: '' + key2 + ''
+                            },
+                            message: 'should NOT have additional properties'
+                          }];
+                          return false;
+                          break;
+                        }
+                      }
+                      if (valid3) {
+                        if (data1.required === undefined) {
+                          valid3 = true;
+                        } else {
+                          var errs_3 = errors;
+                          if (typeof data1.required !== "boolean") {
+                            validate.errors = [{
+                              keyword: 'type',
+                              dataPath: (dataPath || '') + '.validation.required',
+                              schemaPath: '#/definitions/Validation/properties/required/type',
+                              params: {
+                                type: 'boolean'
+                              },
+                              message: 'should be boolean'
+                            }];
+                            return false;
+                          }
+                          var valid3 = errors === errs_3;
+                        }
+                        if (valid3) {
+                          if (data1.requiredAcceptsNull === undefined) {
+                            valid3 = true;
+                          } else {
+                            var errs_3 = errors;
+                            if (typeof data1.requiredAcceptsNull !== "boolean") {
+                              validate.errors = [{
+                                keyword: 'type',
+                                dataPath: (dataPath || '') + '.validation.requiredAcceptsNull',
+                                schemaPath: '#/definitions/Validation/properties/requiredAcceptsNull/type',
+                                params: {
+                                  type: 'boolean'
+                                },
+                                message: 'should be boolean'
+                              }];
+                              return false;
+                            }
+                            var valid3 = errors === errs_3;
+                          }
+                          if (valid3) {
+                            var data2 = data1.minLength;
+                            if (data2 === undefined) {
+                              valid3 = true;
+                            } else {
+                              var errs_3 = errors;
+                              if ((typeof data2 !== "number" || (data2 % 1) || data2 !== data2)) {
+                                validate.errors = [{
+                                  keyword: 'type',
+                                  dataPath: (dataPath || '') + '.validation.minLength',
+                                  schemaPath: '#/definitions/Validation/properties/minLength/type',
+                                  params: {
+                                    type: 'integer'
+                                  },
+                                  message: 'should be integer'
+                                }];
+                                return false;
+                              }
+                              var valid3 = errors === errs_3;
+                            }
+                            if (valid3) {
+                              var data2 = data1.maxLength;
+                              if (data2 === undefined) {
+                                valid3 = true;
+                              } else {
+                                var errs_3 = errors;
+                                if ((typeof data2 !== "number" || (data2 % 1) || data2 !== data2)) {
+                                  validate.errors = [{
+                                    keyword: 'type',
+                                    dataPath: (dataPath || '') + '.validation.maxLength',
+                                    schemaPath: '#/definitions/Validation/properties/maxLength/type',
+                                    params: {
+                                      type: 'integer'
+                                    },
+                                    message: 'should be integer'
+                                  }];
+                                  return false;
+                                }
+                                var valid3 = errors === errs_3;
+                              }
+                              if (valid3) {
+                                var data2 = data1.minValue;
+                                if (data2 === undefined) {
+                                  valid3 = true;
+                                } else {
+                                  var errs_3 = errors;
+                                  if ((typeof data2 !== "number" || (data2 % 1) || data2 !== data2)) {
+                                    validate.errors = [{
+                                      keyword: 'type',
+                                      dataPath: (dataPath || '') + '.validation.minValue',
+                                      schemaPath: '#/definitions/Validation/properties/minValue/type',
+                                      params: {
+                                        type: 'integer'
+                                      },
+                                      message: 'should be integer'
+                                    }];
+                                    return false;
+                                  }
+                                  var valid3 = errors === errs_3;
+                                }
+                                if (valid3) {
+                                  var data2 = data1.maxValue;
+                                  if (data2 === undefined) {
+                                    valid3 = true;
+                                  } else {
+                                    var errs_3 = errors;
+                                    if ((typeof data2 !== "number" || (data2 % 1) || data2 !== data2)) {
+                                      validate.errors = [{
+                                        keyword: 'type',
+                                        dataPath: (dataPath || '') + '.validation.maxValue',
+                                        schemaPath: '#/definitions/Validation/properties/maxValue/type',
+                                        params: {
+                                          type: 'integer'
+                                        },
+                                        message: 'should be integer'
+                                      }];
+                                      return false;
+                                    }
+                                    var valid3 = errors === errs_3;
+                                  }
+                                  if (valid3) {
+                                    var data2 = data1.minSelected;
+                                    if (data2 === undefined) {
+                                      valid3 = true;
+                                    } else {
+                                      var errs_3 = errors;
+                                      if ((typeof data2 !== "number" || (data2 % 1) || data2 !== data2)) {
+                                        validate.errors = [{
+                                          keyword: 'type',
+                                          dataPath: (dataPath || '') + '.validation.minSelected',
+                                          schemaPath: '#/definitions/Validation/properties/minSelected/type',
+                                          params: {
+                                            type: 'integer'
+                                          },
+                                          message: 'should be integer'
+                                        }];
+                                        return false;
+                                      }
+                                      var valid3 = errors === errs_3;
+                                    }
+                                    if (valid3) {
+                                      var data2 = data1.maxSelected;
+                                      if (data2 === undefined) {
+                                        valid3 = true;
+                                      } else {
+                                        var errs_3 = errors;
+                                        if ((typeof data2 !== "number" || (data2 % 1) || data2 !== data2)) {
+                                          validate.errors = [{
+                                            keyword: 'type',
+                                            dataPath: (dataPath || '') + '.validation.maxSelected',
+                                            schemaPath: '#/definitions/Validation/properties/maxSelected/type',
+                                            params: {
+                                              type: 'integer'
+                                            },
+                                            message: 'should be integer'
+                                          }];
+                                          return false;
+                                        }
+                                        var valid3 = errors === errs_3;
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    } else {
+                      validate.errors = [{
+                        keyword: 'type',
+                        dataPath: (dataPath || '') + '.validation',
+                        schemaPath: '#/definitions/Validation/type',
+                        params: {
+                          type: 'object'
+                        },
+                        message: 'should be object'
+                      }];
+                      return false;
+                    }
+                    var valid2 = errors === errs_2;
+                    var valid1 = errors === errs_1;
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal16.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "variable": {
+        "type": "string"
+      },
+      "component": {
+        "type": "string",
+        "enum": ["CheckboxGroup", "Number", "RadioGroup", "Text", "Toggle", "ToggleButtonGroup"]
+      },
+      "prompt": {
+        "type": "string"
+      },
+      "validation": {
+        "$ref": "#/definitions/Validation"
+      }
+    },
+    "required": ["component", "variable", "prompt"],
+    "title": "Field"
+  };
+  refVal16.errors = null;
+  refVal[16] = refVal16;
+  var refVal17 = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "required": {
+        "type": "boolean"
+      },
+      "requiredAcceptsNull": {
+        "type": "boolean"
+      },
+      "minLength": {
+        "type": "integer"
+      },
+      "maxLength": {
+        "type": "integer"
+      },
+      "minValue": {
+        "type": "integer"
+      },
+      "maxValue": {
+        "type": "integer"
+      },
+      "minSelected": {
+        "type": "integer"
+      },
+      "maxSelected": {
+        "type": "integer"
+      }
+    },
+    "title": "Validation"
+  };
+  refVal[17] = refVal17;
+  var refVal18 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'entity' || key0 == 'type');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            var data1 = data.entity;
+            if (data1 === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'entity'
+                },
+                message: 'should have required property \'entity\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              var errs_2 = errors;
+              if (typeof data1 !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.entity',
+                  schemaPath: '#/definitions/Entity/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var schema2 = refVal19.enum;
+              var valid2;
+              valid2 = false;
+              for (var i2 = 0; i2 < schema2.length; i2++)
+                if (equal(data1, schema2[i2])) {
+                  valid2 = true;
+                  break;
+                } if (!valid2) {
+                validate.errors = [{
+                  keyword: 'enum',
+                  dataPath: (dataPath || '') + '.entity',
+                  schemaPath: '#/definitions/Entity/enum',
+                  params: {
+                    allowedValues: schema2
+                  },
+                  message: 'should be equal to one of the allowed values'
+                }];
+                return false;
+              }
+              var valid2 = errors === errs_2;
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              if (data.type === undefined) {
+                valid1 = false;
+                validate.errors = [{
+                  keyword: 'required',
+                  dataPath: (dataPath || '') + "",
+                  schemaPath: '#/required',
+                  params: {
+                    missingProperty: 'type'
+                  },
+                  message: 'should have required property \'type\''
+                }];
+                return false;
+              } else {
+                var errs_1 = errors;
+                if (typeof data.type !== "string") {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.type',
+                    schemaPath: '#/properties/type/type',
+                    params: {
+                      type: 'string'
+                    },
+                    message: 'should be string'
+                  }];
+                  return false;
+                }
+                var valid1 = errors === errs_1;
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal18.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "entity": {
+        "$ref": "#/definitions/Entity"
+      },
+      "type": {
+        "type": "string"
+      }
+    },
+    "required": ["entity", "type"],
+    "title": "Subject"
+  };
+  refVal18.errors = null;
+  refVal[18] = refVal18;
+  var refVal19 = {
+    "type": "string",
+    "enum": ["edge", "node", "ego"],
+    "title": "Entity"
+  };
+  refVal[19] = refVal19;
+  var refVal20 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'id' || key0 == 'title' || key0 == 'filter' || key0 == 'dataSource');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            if (data.id === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'id'
+                },
+                message: 'should have required property \'id\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              if (typeof data.id !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.id',
+                  schemaPath: '#/properties/id/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              if (data.title === undefined) {
+                valid1 = false;
+                validate.errors = [{
+                  keyword: 'required',
+                  dataPath: (dataPath || '') + "",
+                  schemaPath: '#/required',
+                  params: {
+                    missingProperty: 'title'
+                  },
+                  message: 'should have required property \'title\''
+                }];
+                return false;
+              } else {
+                var errs_1 = errors;
+                if (typeof data.title !== "string") {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.title',
+                    schemaPath: '#/properties/title/type',
+                    params: {
+                      type: 'string'
+                    },
+                    message: 'should be string'
+                  }];
+                  return false;
+                }
+                var valid1 = errors === errs_1;
+              }
+              if (valid1) {
+                if (data.filter === undefined) {
+                  valid1 = true;
+                } else {
+                  var errs_1 = errors;
+                  if (!refVal21(data.filter, (dataPath || '') + '.filter', data, 'filter', rootData)) {
+                    if (vErrors === null) vErrors = refVal21.errors;
+                    else vErrors = vErrors.concat(refVal21.errors);
+                    errors = vErrors.length;
+                  }
+                  var valid1 = errors === errs_1;
+                }
+                if (valid1) {
+                  var data1 = data.dataSource;
+                  if (data1 === undefined) {
+                    valid1 = false;
+                    validate.errors = [{
+                      keyword: 'required',
+                      dataPath: (dataPath || '') + "",
+                      schemaPath: '#/required',
+                      params: {
+                        missingProperty: 'dataSource'
+                      },
+                      message: 'should have required property \'dataSource\''
+                    }];
+                    return false;
+                  } else {
+                    var errs_1 = errors;
+                    if (typeof data1 !== "string" && data1 !== null) {
+                      validate.errors = [{
+                        keyword: 'type',
+                        dataPath: (dataPath || '') + '.dataSource',
+                        schemaPath: '#/properties/dataSource/type',
+                        params: {
+                          type: 'string,null'
+                        },
+                        message: 'should be string,null'
+                      }];
+                      return false;
+                    }
+                    var valid1 = errors === errs_1;
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal20.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      },
+      "filter": {
+        "$ref": "#/definitions/Filter"
+      },
+      "dataSource": {
+        "type": ["string", "null"]
+      }
+    },
+    "required": ["id", "title", "dataSource"],
+    "title": "Panel"
+  };
+  refVal20.errors = null;
+  refVal[20] = refVal20;
+  var refVal21 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      if ((!data || typeof data !== "object" || Array.isArray(data)) && data !== null) {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object,null'
+          },
+          message: 'should be object,null'
+        }];
+        return false;
+      }
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        var errs__0 = errors;
+        var valid1 = true;
+        for (var key0 in data) {
+          var isAdditional0 = !(false || key0 == 'join' || key0 == 'rules');
+          if (isAdditional0) {
+            valid1 = false;
+            validate.errors = [{
+              keyword: 'additionalProperties',
+              dataPath: (dataPath || '') + "",
+              schemaPath: '#/additionalProperties',
+              params: {
+                additionalProperty: '' + key0 + ''
+              },
+              message: 'should NOT have additional properties'
+            }];
+            return false;
+            break;
+          }
+        }
+        if (valid1) {
+          var data1 = data.join;
+          if (data1 === undefined) {
+            valid1 = true;
+          } else {
+            var errs_1 = errors;
+            if (typeof data1 !== "string") {
+              validate.errors = [{
+                keyword: 'type',
+                dataPath: (dataPath || '') + '.join',
+                schemaPath: '#/properties/join/type',
+                params: {
+                  type: 'string'
+                },
+                message: 'should be string'
+              }];
+              return false;
+            }
+            var schema1 = validate.schema.properties.join.enum;
+            var valid1;
+            valid1 = false;
+            for (var i1 = 0; i1 < schema1.length; i1++)
+              if (equal(data1, schema1[i1])) {
+                valid1 = true;
+                break;
+              } if (!valid1) {
+              validate.errors = [{
+                keyword: 'enum',
+                dataPath: (dataPath || '') + '.join',
+                schemaPath: '#/properties/join/enum',
+                params: {
+                  allowedValues: schema1
+                },
+                message: 'should be equal to one of the allowed values'
+              }];
+              return false;
+            }
+            var valid1 = errors === errs_1;
+          }
+          if (valid1) {
+            var data1 = data.rules;
+            if (data1 === undefined) {
+              valid1 = true;
+            } else {
+              var errs_1 = errors;
+              if (Array.isArray(data1)) {
+                var errs__1 = errors;
+                var valid1;
+                for (var i1 = 0; i1 < data1.length; i1++) {
+                  var errs_2 = errors;
+                  if (!refVal22(data1[i1], (dataPath || '') + '.rules[' + i1 + ']', data1, i1, rootData)) {
+                    if (vErrors === null) vErrors = refVal22.errors;
+                    else vErrors = vErrors.concat(refVal22.errors);
+                    errors = vErrors.length;
+                  }
+                  var valid2 = errors === errs_2;
+                  if (!valid2) break;
+                }
+              } else {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.rules',
+                  schemaPath: '#/properties/rules/type',
+                  params: {
+                    type: 'array'
+                  },
+                  message: 'should be array'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+          }
+        }
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal21.schema = {
+    "type": ["object", "null"],
+    "additionalProperties": false,
+    "properties": {
+      "join": {
+        "type": "string",
+        "enum": ["OR", "AND"]
+      },
+      "rules": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Rule"
+        }
+      }
+    },
+    "title": "Filter"
+  };
+  refVal21.errors = null;
+  refVal[21] = refVal21;
+  var refVal22 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'type' || key0 == 'id' || key0 == 'options');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            var data1 = data.type;
+            if (data1 === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'type'
+                },
+                message: 'should have required property \'type\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              if (typeof data1 !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.type',
+                  schemaPath: '#/properties/type/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var schema1 = validate.schema.properties.type.enum;
+              var valid1;
+              valid1 = false;
+              for (var i1 = 0; i1 < schema1.length; i1++)
+                if (equal(data1, schema1[i1])) {
+                  valid1 = true;
+                  break;
+                } if (!valid1) {
+                validate.errors = [{
+                  keyword: 'enum',
+                  dataPath: (dataPath || '') + '.type',
+                  schemaPath: '#/properties/type/enum',
+                  params: {
+                    allowedValues: schema1
+                  },
+                  message: 'should be equal to one of the allowed values'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              if (data.id === undefined) {
+                valid1 = false;
+                validate.errors = [{
+                  keyword: 'required',
+                  dataPath: (dataPath || '') + "",
+                  schemaPath: '#/required',
+                  params: {
+                    missingProperty: 'id'
+                  },
+                  message: 'should have required property \'id\''
+                }];
+                return false;
+              } else {
+                var errs_1 = errors;
+                if (typeof data.id !== "string") {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.id',
+                    schemaPath: '#/properties/id/type',
+                    params: {
+                      type: 'string'
+                    },
+                    message: 'should be string'
+                  }];
+                  return false;
+                }
+                var valid1 = errors === errs_1;
+              }
+              if (valid1) {
+                var data1 = data.options;
+                if (data1 === undefined) {
+                  valid1 = false;
+                  validate.errors = [{
+                    keyword: 'required',
+                    dataPath: (dataPath || '') + "",
+                    schemaPath: '#/required',
+                    params: {
+                      missingProperty: 'options'
+                    },
+                    message: 'should have required property \'options\''
+                  }];
+                  return false;
+                } else {
+                  var errs_1 = errors;
+                  var errs_2 = errors;
+                  if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
+                    if (true) {
+                      var errs__2 = errors;
+                      var valid3 = true;
+                      for (var key2 in data1) {
+                        var isAdditional2 = !(false || key2 == 'type' || key2 == 'attribute' || key2 == 'operator' || key2 == 'value');
+                        if (isAdditional2) {
+                          valid3 = false;
+                          validate.errors = [{
+                            keyword: 'additionalProperties',
+                            dataPath: (dataPath || '') + '.options',
+                            schemaPath: '#/definitions/Options/additionalProperties',
+                            params: {
+                              additionalProperty: '' + key2 + ''
+                            },
+                            message: 'should NOT have additional properties'
+                          }];
+                          return false;
+                          break;
+                        }
+                      }
+                      if (valid3) {
+                        if (data1.type === undefined) {
+                          valid3 = true;
+                        } else {
+                          var errs_3 = errors;
+                          if (typeof data1.type !== "string") {
+                            validate.errors = [{
+                              keyword: 'type',
+                              dataPath: (dataPath || '') + '.options.type',
+                              schemaPath: '#/definitions/Options/properties/type/type',
+                              params: {
+                                type: 'string'
+                              },
+                              message: 'should be string'
+                            }];
+                            return false;
+                          }
+                          var valid3 = errors === errs_3;
+                        }
+                        if (valid3) {
+                          if (data1.attribute === undefined) {
+                            valid3 = true;
+                          } else {
+                            var errs_3 = errors;
+                            if (typeof data1.attribute !== "string") {
+                              validate.errors = [{
+                                keyword: 'type',
+                                dataPath: (dataPath || '') + '.options.attribute',
+                                schemaPath: '#/definitions/Options/properties/attribute/type',
+                                params: {
+                                  type: 'string'
+                                },
+                                message: 'should be string'
+                              }];
+                              return false;
+                            }
+                            var valid3 = errors === errs_3;
+                          }
+                          if (valid3) {
+                            var data2 = data1.operator;
+                            if (data2 === undefined) {
+                              valid3 = false;
+                              validate.errors = [{
+                                keyword: 'required',
+                                dataPath: (dataPath || '') + '.options',
+                                schemaPath: '#/definitions/Options/required',
+                                params: {
+                                  missingProperty: 'operator'
+                                },
+                                message: 'should have required property \'operator\''
+                              }];
+                              return false;
+                            } else {
+                              var errs_3 = errors;
+                              if (typeof data2 !== "string") {
+                                validate.errors = [{
+                                  keyword: 'type',
+                                  dataPath: (dataPath || '') + '.options.operator',
+                                  schemaPath: '#/definitions/Options/properties/operator/type',
+                                  params: {
+                                    type: 'string'
+                                  },
+                                  message: 'should be string'
+                                }];
+                                return false;
+                              }
+                              var schema3 = refVal23.properties.operator.enum;
+                              var valid3;
+                              valid3 = false;
+                              for (var i3 = 0; i3 < schema3.length; i3++)
+                                if (equal(data2, schema3[i3])) {
+                                  valid3 = true;
+                                  break;
+                                } if (!valid3) {
+                                validate.errors = [{
+                                  keyword: 'enum',
+                                  dataPath: (dataPath || '') + '.options.operator',
+                                  schemaPath: '#/definitions/Options/properties/operator/enum',
+                                  params: {
+                                    allowedValues: schema3
+                                  },
+                                  message: 'should be equal to one of the allowed values'
+                                }];
+                                return false;
+                              }
+                              var valid3 = errors === errs_3;
+                            }
+                            if (valid3) {
+                              if (data1.value === undefined) {
+                                valid3 = true;
+                              } else {
+                                var errs_3 = errors;
+                                if (typeof data1.value !== "string") {
+                                  validate.errors = [{
+                                    keyword: 'type',
+                                    dataPath: (dataPath || '') + '.options.value',
+                                    schemaPath: '#/definitions/Options/properties/value/type',
+                                    params: {
+                                      type: 'string'
+                                    },
+                                    message: 'should be string'
+                                  }];
+                                  return false;
+                                }
+                                var valid3 = errors === errs_3;
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  } else {
+                    validate.errors = [{
+                      keyword: 'type',
+                      dataPath: (dataPath || '') + '.options',
+                      schemaPath: '#/definitions/Options/type',
+                      params: {
+                        type: 'object'
+                      },
+                      message: 'should be object'
+                    }];
+                    return false;
+                  }
+                  if (errors === errs_2) {
+                    var errs_3 = errors;
+                    var errs__3 = errors;
+                    var valid3 = true;
+                    var errs_4 = errors;
+                    if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
+                      var errs__4 = errors;
+                      var valid5 = true;
+                      if (data1.operator === undefined) {
+                        valid5 = true;
+                      } else {
+                        var errs_5 = errors;
+                        var schema5 = refVal23.allOf[0].if.properties.operator.enum;
+                        var valid5;
+                        valid5 = false;
+                        for (var i5 = 0; i5 < schema5.length; i5++)
+                          if (equal(data1.operator, schema5[i5])) {
+                            valid5 = true;
+                            break;
+                          } if (!valid5) {
+                          var err = {};
+                          if (vErrors === null) vErrors = [err];
+                          else vErrors.push(err);
+                          errors++;
+                        }
+                        var valid5 = errors === errs_5;
+                      }
+                    }
+                    var valid4 = errors === errs_4;
+                    errors = errs__3;
+                    if (vErrors !== null) {
+                      if (errs__3) vErrors.length = errs__3;
+                      else vErrors = null;
+                    }
+                    if (valid4) {
+                      var errs_4 = errors;
+                      if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
+                        var missing4;
+                        if (((data1.value === undefined) && (missing4 = '.value'))) {
+                          validate.errors = [{
+                            keyword: 'required',
+                            dataPath: (dataPath || '') + '.options',
+                            schemaPath: '#/definitions/Options/allOf/0/then/required',
+                            params: {
+                              missingProperty: '' + missing4 + ''
+                            },
+                            message: 'should have required property \'' + missing4 + '\''
+                          }];
+                          return false;
+                        }
+                      }
+                      var valid4 = errors === errs_4;
+                      valid3 = valid4;
+                    }
+                    if (!valid3) {
+                      var err = {
+                        keyword: 'if',
+                        dataPath: (dataPath || '') + '.options',
+                        schemaPath: '#/definitions/Options/allOf/0/if',
+                        params: {
+                          failingKeyword: 'then'
+                        },
+                        message: 'should match "' + 'then' + '" schema'
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                      validate.errors = vErrors;
+                      return false;
+                    }
+                    var valid3 = errors === errs_3;
+                  }
+                  var valid2 = errors === errs_2;
+                  var valid1 = errors === errs_1;
+                }
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal22.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": ["alter", "ego", "edge"]
+      },
+      "id": {
+        "type": "string"
+      },
+      "options": {
+        "$ref": "#/definitions/Options"
+      }
+    },
+    "required": ["id", "options", "type"],
+    "title": "Rule"
+  };
+  refVal22.errors = null;
+  refVal[22] = refVal22;
+  var refVal23 = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "type": {
+        "type": "string"
+      },
+      "attribute": {
+        "type": "string"
+      },
+      "operator": {
+        "type": "string",
+        "enum": ["EXISTS", "NOT_EXISTS", "EXACTLY", "NOT", "GREATER_THAN", "GREATER_THAN_OR_EQUAL", "LESS_THAN", "LESS_THAN_OR_EQUAL"]
+      },
+      "value": {
+        "type": "string"
+      }
+    },
+    "required": ["operator"],
+    "title": "Rule Options",
+    "allOf": [{
+      "if": {
+        "properties": {
+          "operator": {
+            "enum": ["EXACTLY", "NOT", "GREATER_THAN", "GREATER_THAN_OR_EQUAL", "LESS_THAN", "LESS_THAN_OR_EQUAL"]
+          }
+        }
+      },
+      "then": {
+        "required": ["value"]
+      }
+    }]
+  };
+  refVal[23] = refVal23;
+  var refVal24 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || validate.schema.properties.hasOwnProperty(key0));
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            if (data.id === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'id'
+                },
+                message: 'should have required property \'id\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              if (typeof data.id !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.id',
+                  schemaPath: '#/properties/id/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              if (data.text === undefined) {
+                valid1 = false;
+                validate.errors = [{
+                  keyword: 'required',
+                  dataPath: (dataPath || '') + "",
+                  schemaPath: '#/required',
+                  params: {
+                    missingProperty: 'text'
+                  },
+                  message: 'should have required property \'text\''
+                }];
+                return false;
+              } else {
+                var errs_1 = errors;
+                if (typeof data.text !== "string") {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.text',
+                    schemaPath: '#/properties/text/type',
+                    params: {
+                      type: 'string'
+                    },
+                    message: 'should be string'
+                  }];
+                  return false;
+                }
+                var valid1 = errors === errs_1;
+              }
+              if (valid1) {
+                if (data.additionalAttributes === undefined) {
+                  valid1 = true;
+                } else {
+                  var errs_1 = errors;
+                  if (!refVal25(data.additionalAttributes, (dataPath || '') + '.additionalAttributes', data, 'additionalAttributes', rootData)) {
+                    if (vErrors === null) vErrors = refVal25.errors;
+                    else vErrors = vErrors.concat(refVal25.errors);
+                    errors = vErrors.length;
+                  }
+                  var valid1 = errors === errs_1;
+                }
+                if (valid1) {
+                  if (data.variable === undefined) {
+                    valid1 = true;
+                  } else {
+                    var errs_1 = errors;
+                    if (typeof data.variable !== "string") {
+                      validate.errors = [{
+                        keyword: 'type',
+                        dataPath: (dataPath || '') + '.variable',
+                        schemaPath: '#/properties/variable/type',
+                        params: {
+                          type: 'string'
+                        },
+                        message: 'should be string'
+                      }];
+                      return false;
+                    }
+                    var valid1 = errors === errs_1;
+                  }
+                  if (valid1) {
+                    var data1 = data.bucketSortOrder;
+                    if (data1 === undefined) {
+                      valid1 = true;
+                    } else {
+                      var errs_1 = errors;
+                      if (Array.isArray(data1)) {
+                        var errs__1 = errors;
+                        var valid1;
+                        for (var i1 = 0; i1 < data1.length; i1++) {
+                          var errs_2 = errors;
+                          if (!refVal27(data1[i1], (dataPath || '') + '.bucketSortOrder[' + i1 + ']', data1, i1, rootData)) {
+                            if (vErrors === null) vErrors = refVal27.errors;
+                            else vErrors = vErrors.concat(refVal27.errors);
+                            errors = vErrors.length;
+                          }
+                          var valid2 = errors === errs_2;
+                          if (!valid2) break;
+                        }
+                      } else {
+                        validate.errors = [{
+                          keyword: 'type',
+                          dataPath: (dataPath || '') + '.bucketSortOrder',
+                          schemaPath: '#/properties/bucketSortOrder/type',
+                          params: {
+                            type: 'array'
+                          },
+                          message: 'should be array'
+                        }];
+                        return false;
+                      }
+                      var valid1 = errors === errs_1;
+                    }
+                    if (valid1) {
+                      var data1 = data.binSortOrder;
+                      if (data1 === undefined) {
+                        valid1 = true;
+                      } else {
+                        var errs_1 = errors;
+                        if (Array.isArray(data1)) {
+                          var errs__1 = errors;
+                          var valid1;
+                          for (var i1 = 0; i1 < data1.length; i1++) {
+                            var errs_2 = errors;
+                            if (!refVal[27](data1[i1], (dataPath || '') + '.binSortOrder[' + i1 + ']', data1, i1, rootData)) {
+                              if (vErrors === null) vErrors = refVal[27].errors;
+                              else vErrors = vErrors.concat(refVal[27].errors);
+                              errors = vErrors.length;
+                            }
+                            var valid2 = errors === errs_2;
+                            if (!valid2) break;
+                          }
+                        } else {
+                          validate.errors = [{
+                            keyword: 'type',
+                            dataPath: (dataPath || '') + '.binSortOrder',
+                            schemaPath: '#/properties/binSortOrder/type',
+                            params: {
+                              type: 'array'
+                            },
+                            message: 'should be array'
+                          }];
+                          return false;
+                        }
+                        var valid1 = errors === errs_1;
+                      }
+                      if (valid1) {
+                        var data1 = data.sortOrder;
+                        if (data1 === undefined) {
+                          valid1 = true;
+                        } else {
+                          var errs_1 = errors;
+                          if (Array.isArray(data1)) {
+                            var errs__1 = errors;
+                            var valid1;
+                            for (var i1 = 0; i1 < data1.length; i1++) {
+                              var errs_2 = errors;
+                              if (!refVal[27](data1[i1], (dataPath || '') + '.sortOrder[' + i1 + ']', data1, i1, rootData)) {
+                                if (vErrors === null) vErrors = refVal[27].errors;
+                                else vErrors = vErrors.concat(refVal[27].errors);
+                                errors = vErrors.length;
+                              }
+                              var valid2 = errors === errs_2;
+                              if (!valid2) break;
+                            }
+                          } else {
+                            validate.errors = [{
+                              keyword: 'type',
+                              dataPath: (dataPath || '') + '.sortOrder',
+                              schemaPath: '#/properties/sortOrder/type',
+                              params: {
+                                type: 'array'
+                              },
+                              message: 'should be array'
+                            }];
+                            return false;
+                          }
+                          var valid1 = errors === errs_1;
+                        }
+                        if (valid1) {
+                          if (data.color === undefined) {
+                            valid1 = true;
+                          } else {
+                            var errs_1 = errors;
+                            if (typeof data.color !== "string") {
+                              validate.errors = [{
+                                keyword: 'type',
+                                dataPath: (dataPath || '') + '.color',
+                                schemaPath: '#/properties/color/type',
+                                params: {
+                                  type: 'string'
+                                },
+                                message: 'should be string'
+                              }];
+                              return false;
+                            }
+                            var valid1 = errors === errs_1;
+                          }
+                          if (valid1) {
+                            var data1 = data.layout;
+                            if (data1 === undefined) {
+                              valid1 = true;
+                            } else {
+                              var errs_1 = errors;
+                              var errs_2 = errors;
+                              if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
+                                if (true) {
+                                  var errs__2 = errors;
+                                  var valid3 = true;
+                                  for (var key2 in data1) {
+                                    var isAdditional2 = !(false || key2 == 'layoutVariable' || key2 == 'allowPositioning');
+                                    if (isAdditional2) {
+                                      valid3 = false;
+                                      validate.errors = [{
+                                        keyword: 'additionalProperties',
+                                        dataPath: (dataPath || '') + '.layout',
+                                        schemaPath: '#/definitions/Layout/additionalProperties',
+                                        params: {
+                                          additionalProperty: '' + key2 + ''
+                                        },
+                                        message: 'should NOT have additional properties'
+                                      }];
+                                      return false;
+                                      break;
+                                    }
+                                  }
+                                  if (valid3) {
+                                    if (data1.layoutVariable === undefined) {
+                                      valid3 = false;
+                                      validate.errors = [{
+                                        keyword: 'required',
+                                        dataPath: (dataPath || '') + '.layout',
+                                        schemaPath: '#/definitions/Layout/required',
+                                        params: {
+                                          missingProperty: 'layoutVariable'
+                                        },
+                                        message: 'should have required property \'layoutVariable\''
+                                      }];
+                                      return false;
+                                    } else {
+                                      var errs_3 = errors;
+                                      if (typeof data1.layoutVariable !== "string") {
+                                        validate.errors = [{
+                                          keyword: 'type',
+                                          dataPath: (dataPath || '') + '.layout.layoutVariable',
+                                          schemaPath: '#/definitions/Layout/properties/layoutVariable/type',
+                                          params: {
+                                            type: 'string'
+                                          },
+                                          message: 'should be string'
+                                        }];
+                                        return false;
+                                      }
+                                      var valid3 = errors === errs_3;
+                                    }
+                                    if (valid3) {
+                                      if (data1.allowPositioning === undefined) {
+                                        valid3 = true;
+                                      } else {
+                                        var errs_3 = errors;
+                                        if (typeof data1.allowPositioning !== "boolean") {
+                                          validate.errors = [{
+                                            keyword: 'type',
+                                            dataPath: (dataPath || '') + '.layout.allowPositioning',
+                                            schemaPath: '#/definitions/Layout/properties/allowPositioning/type',
+                                            params: {
+                                              type: 'boolean'
+                                            },
+                                            message: 'should be boolean'
+                                          }];
+                                          return false;
+                                        }
+                                        var valid3 = errors === errs_3;
+                                      }
+                                    }
+                                  }
+                                }
+                              } else {
+                                validate.errors = [{
+                                  keyword: 'type',
+                                  dataPath: (dataPath || '') + '.layout',
+                                  schemaPath: '#/definitions/Layout/type',
+                                  params: {
+                                    type: 'object'
+                                  },
+                                  message: 'should be object'
+                                }];
+                                return false;
+                              }
+                              var valid2 = errors === errs_2;
+                              var valid1 = errors === errs_1;
+                            }
+                            if (valid1) {
+                              var data1 = data.edges;
+                              if (data1 === undefined) {
+                                valid1 = true;
+                              } else {
+                                var errs_1 = errors;
+                                var errs_2 = errors;
+                                if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
+                                  if (true) {
+                                    var errs__2 = errors;
+                                    var valid3 = true;
+                                    for (var key2 in data1) {
+                                      var isAdditional2 = !(false || key2 == 'display' || key2 == 'create');
+                                      if (isAdditional2) {
+                                        valid3 = false;
+                                        validate.errors = [{
+                                          keyword: 'additionalProperties',
+                                          dataPath: (dataPath || '') + '.edges',
+                                          schemaPath: '#/definitions/Edges/additionalProperties',
+                                          params: {
+                                            additionalProperty: '' + key2 + ''
+                                          },
+                                          message: 'should NOT have additional properties'
+                                        }];
+                                        return false;
+                                        break;
+                                      }
+                                    }
+                                    if (valid3) {
+                                      var data2 = data1.display;
+                                      if (data2 === undefined) {
+                                        valid3 = true;
+                                      } else {
+                                        var errs_3 = errors;
+                                        if (Array.isArray(data2)) {
+                                          var errs__3 = errors;
+                                          var valid3;
+                                          for (var i3 = 0; i3 < data2.length; i3++) {
+                                            var errs_4 = errors;
+                                            if (typeof data2[i3] !== "string") {
+                                              validate.errors = [{
+                                                keyword: 'type',
+                                                dataPath: (dataPath || '') + '.edges.display[' + i3 + ']',
+                                                schemaPath: '#/definitions/Edges/properties/display/items/type',
+                                                params: {
+                                                  type: 'string'
+                                                },
+                                                message: 'should be string'
+                                              }];
+                                              return false;
+                                            }
+                                            var valid4 = errors === errs_4;
+                                            if (!valid4) break;
+                                          }
+                                        } else {
+                                          validate.errors = [{
+                                            keyword: 'type',
+                                            dataPath: (dataPath || '') + '.edges.display',
+                                            schemaPath: '#/definitions/Edges/properties/display/type',
+                                            params: {
+                                              type: 'array'
+                                            },
+                                            message: 'should be array'
+                                          }];
+                                          return false;
+                                        }
+                                        var valid3 = errors === errs_3;
+                                      }
+                                      if (valid3) {
+                                        if (data1.create === undefined) {
+                                          valid3 = true;
+                                        } else {
+                                          var errs_3 = errors;
+                                          if (typeof data1.create !== "string") {
+                                            validate.errors = [{
+                                              keyword: 'type',
+                                              dataPath: (dataPath || '') + '.edges.create',
+                                              schemaPath: '#/definitions/Edges/properties/create/type',
+                                              params: {
+                                                type: 'string'
+                                              },
+                                              message: 'should be string'
+                                            }];
+                                            return false;
+                                          }
+                                          var valid3 = errors === errs_3;
+                                        }
+                                      }
+                                    }
+                                  }
+                                } else {
+                                  validate.errors = [{
+                                    keyword: 'type',
+                                    dataPath: (dataPath || '') + '.edges',
+                                    schemaPath: '#/definitions/Edges/type',
+                                    params: {
+                                      type: 'object'
+                                    },
+                                    message: 'should be object'
+                                  }];
+                                  return false;
+                                }
+                                var valid2 = errors === errs_2;
+                                var valid1 = errors === errs_1;
+                              }
+                              if (valid1) {
+                                var data1 = data.highlight;
+                                if (data1 === undefined) {
+                                  valid1 = true;
+                                } else {
+                                  var errs_1 = errors;
+                                  var errs_2 = errors;
+                                  if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
+                                    if (true) {
+                                      var errs__2 = errors;
+                                      var valid3 = true;
+                                      for (var key2 in data1) {
+                                        var isAdditional2 = !(false || key2 == 'variable' || key2 == 'allowHighlighting');
+                                        if (isAdditional2) {
+                                          valid3 = false;
+                                          validate.errors = [{
+                                            keyword: 'additionalProperties',
+                                            dataPath: (dataPath || '') + '.highlight',
+                                            schemaPath: '#/definitions/Highlight/additionalProperties',
+                                            params: {
+                                              additionalProperty: '' + key2 + ''
+                                            },
+                                            message: 'should NOT have additional properties'
+                                          }];
+                                          return false;
+                                          break;
+                                        }
+                                      }
+                                      if (valid3) {
+                                        if (data1.variable === undefined) {
+                                          valid3 = true;
+                                        } else {
+                                          var errs_3 = errors;
+                                          if (typeof data1.variable !== "string") {
+                                            validate.errors = [{
+                                              keyword: 'type',
+                                              dataPath: (dataPath || '') + '.highlight.variable',
+                                              schemaPath: '#/definitions/Highlight/properties/variable/type',
+                                              params: {
+                                                type: 'string'
+                                              },
+                                              message: 'should be string'
+                                            }];
+                                            return false;
+                                          }
+                                          var valid3 = errors === errs_3;
+                                        }
+                                        if (valid3) {
+                                          if (data1.allowHighlighting === undefined) {
+                                            valid3 = false;
+                                            validate.errors = [{
+                                              keyword: 'required',
+                                              dataPath: (dataPath || '') + '.highlight',
+                                              schemaPath: '#/definitions/Highlight/required',
+                                              params: {
+                                                missingProperty: 'allowHighlighting'
+                                              },
+                                              message: 'should have required property \'allowHighlighting\''
+                                            }];
+                                            return false;
+                                          } else {
+                                            var errs_3 = errors;
+                                            if (typeof data1.allowHighlighting !== "boolean") {
+                                              validate.errors = [{
+                                                keyword: 'type',
+                                                dataPath: (dataPath || '') + '.highlight.allowHighlighting',
+                                                schemaPath: '#/definitions/Highlight/properties/allowHighlighting/type',
+                                                params: {
+                                                  type: 'boolean'
+                                                },
+                                                message: 'should be boolean'
+                                              }];
+                                              return false;
+                                            }
+                                            var valid3 = errors === errs_3;
+                                          }
+                                        }
+                                      }
+                                    }
+                                  } else {
+                                    validate.errors = [{
+                                      keyword: 'type',
+                                      dataPath: (dataPath || '') + '.highlight',
+                                      schemaPath: '#/definitions/Highlight/type',
+                                      params: {
+                                        type: 'object'
+                                      },
+                                      message: 'should be object'
+                                    }];
+                                    return false;
+                                  }
+                                  var valid2 = errors === errs_2;
+                                  var valid1 = errors === errs_1;
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal24.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "text": {
+        "type": "string"
+      },
+      "additionalAttributes": {
+        "$ref": "#/definitions/AdditionalAttributes"
+      },
+      "variable": {
+        "type": "string"
+      },
+      "bucketSortOrder": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/SortOrder"
+        }
+      },
+      "binSortOrder": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/SortOrder"
+        }
+      },
+      "sortOrder": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/SortOrder"
+        }
+      },
+      "color": {
+        "type": "string"
+      },
+      "layout": {
+        "$ref": "#/definitions/Layout"
+      },
+      "edges": {
+        "$ref": "#/definitions/Edges"
+      },
+      "highlight": {
+        "$ref": "#/definitions/Highlight"
+      }
+    },
+    "required": ["id", "text"],
+    "title": "Prompt"
+  };
+  refVal24.errors = null;
+  refVal[24] = refVal24;
+  var refVal25 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (Array.isArray(data)) {
+        var errs__0 = errors;
+        var valid0;
+        for (var i0 = 0; i0 < data.length; i0++) {
+          var data1 = data[i0];
+          var errs_1 = errors;
+          var errs_2 = errors;
+          if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
+            if (true) {
+              var errs__2 = errors;
+              var valid3 = true;
+              for (var key2 in data1) {
+                var isAdditional2 = !(false || key2 == 'variable' || key2 == 'value');
+                if (isAdditional2) {
+                  valid3 = false;
+                  validate.errors = [{
+                    keyword: 'additionalProperties',
+                    dataPath: (dataPath || '') + '[' + i0 + ']',
+                    schemaPath: '#/definitions/AdditionalAttribute/additionalProperties',
+                    params: {
+                      additionalProperty: '' + key2 + ''
+                    },
+                    message: 'should NOT have additional properties'
+                  }];
+                  return false;
+                  break;
+                }
+              }
+              if (valid3) {
+                if (data1.variable === undefined) {
+                  valid3 = false;
+                  validate.errors = [{
+                    keyword: 'required',
+                    dataPath: (dataPath || '') + '[' + i0 + ']',
+                    schemaPath: '#/definitions/AdditionalAttribute/required',
+                    params: {
+                      missingProperty: 'variable'
+                    },
+                    message: 'should have required property \'variable\''
+                  }];
+                  return false;
+                } else {
+                  var errs_3 = errors;
+                  if (typeof data1.variable !== "string") {
+                    validate.errors = [{
+                      keyword: 'type',
+                      dataPath: (dataPath || '') + '[' + i0 + '].variable',
+                      schemaPath: '#/definitions/AdditionalAttribute/properties/variable/type',
+                      params: {
+                        type: 'string'
+                      },
+                      message: 'should be string'
+                    }];
+                    return false;
+                  }
+                  var valid3 = errors === errs_3;
+                }
+                if (valid3) {
+                  var data2 = data1.value;
+                  if (data2 === undefined) {
+                    valid3 = false;
+                    validate.errors = [{
+                      keyword: 'required',
+                      dataPath: (dataPath || '') + '[' + i0 + ']',
+                      schemaPath: '#/definitions/AdditionalAttribute/required',
+                      params: {
+                        missingProperty: 'value'
+                      },
+                      message: 'should have required property \'value\''
+                    }];
+                    return false;
+                  } else {
+                    var errs_3 = errors;
+                    if ((typeof data2 !== "number" || (data2 % 1) || data2 !== data2) && typeof data2 !== "string" && !Array.isArray(data2) && typeof data2 !== "boolean") {
+                      validate.errors = [{
+                        keyword: 'type',
+                        dataPath: (dataPath || '') + '[' + i0 + '].value',
+                        schemaPath: '#/definitions/AdditionalAttribute/properties/value/type',
+                        params: {
+                          type: 'integer,string,array,boolean'
+                        },
+                        message: 'should be integer,string,array,boolean'
+                      }];
+                      return false;
+                    }
+                    var valid3 = errors === errs_3;
+                  }
+                }
+              }
+            }
+          } else {
+            validate.errors = [{
+              keyword: 'type',
+              dataPath: (dataPath || '') + '[' + i0 + ']',
+              schemaPath: '#/definitions/AdditionalAttribute/type',
+              params: {
+                type: 'object'
+              },
+              message: 'should be object'
+            }];
+            return false;
+          }
+          var valid2 = errors === errs_2;
+          var valid1 = errors === errs_1;
+          if (!valid1) break;
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'array'
+          },
+          message: 'should be array'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal25.schema = {
+    "type": "array",
+    "title": "AdditionalAttributes",
+    "items": {
+      "$ref": "#/definitions/AdditionalAttribute"
+    }
+  };
+  refVal25.errors = null;
+  refVal[25] = refVal25;
+  var refVal26 = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "variable": {
+        "type": "string"
+      },
+      "value": {
+        "type": ["integer", "string", "array", "boolean"]
+      }
+    },
+    "required": ["variable", "value"],
+    "title": "AdditionalAttribute"
+  };
+  refVal[26] = refVal26;
+  var refVal27 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'property' || key0 == 'direction');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            if (data.property === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'property'
+                },
+                message: 'should have required property \'property\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              if (typeof data.property !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.property',
+                  schemaPath: '#/properties/property/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              var data1 = data.direction;
+              if (data1 === undefined) {
+                valid1 = false;
+                validate.errors = [{
+                  keyword: 'required',
+                  dataPath: (dataPath || '') + "",
+                  schemaPath: '#/required',
+                  params: {
+                    missingProperty: 'direction'
+                  },
+                  message: 'should have required property \'direction\''
+                }];
+                return false;
+              } else {
+                var errs_1 = errors;
+                var errs_2 = errors;
+                if (typeof data1 !== "string") {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.direction',
+                    schemaPath: '#/definitions/Direction/type',
+                    params: {
+                      type: 'string'
+                    },
+                    message: 'should be string'
+                  }];
+                  return false;
+                }
+                var schema2 = refVal28.enum;
+                var valid2;
+                valid2 = false;
+                for (var i2 = 0; i2 < schema2.length; i2++)
+                  if (equal(data1, schema2[i2])) {
+                    valid2 = true;
+                    break;
+                  } if (!valid2) {
+                  validate.errors = [{
+                    keyword: 'enum',
+                    dataPath: (dataPath || '') + '.direction',
+                    schemaPath: '#/definitions/Direction/enum',
+                    params: {
+                      allowedValues: schema2
+                    },
+                    message: 'should be equal to one of the allowed values'
+                  }];
+                  return false;
+                }
+                var valid2 = errors === errs_2;
+                var valid1 = errors === errs_1;
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal27.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "property": {
+        "type": "string"
+      },
+      "direction": {
+        "$ref": "#/definitions/Direction"
+      }
+    },
+    "required": ["direction", "property"],
+    "title": "SortOrder"
+  };
+  refVal27.errors = null;
+  refVal[27] = refVal27;
+  var refVal28 = {
+    "type": "string",
+    "enum": ["desc", "asc"],
+    "title": "Direction"
+  };
+  refVal[28] = refVal28;
+  var refVal29 = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "layoutVariable": {
+        "type": "string"
+      },
+      "allowPositioning": {
+        "type": "boolean"
+      }
+    },
+    "required": ["layoutVariable"],
+    "title": "Layout"
+  };
+  refVal[29] = refVal29;
+  var refVal30 = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "display": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "create": {
+        "type": "string"
+      }
+    },
+    "required": [],
+    "title": "Edges"
+  };
+  refVal[30] = refVal30;
+  var refVal31 = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "variable": {
+        "type": "string"
+      },
+      "allowHighlighting": {
+        "type": "boolean"
+      }
+    },
+    "required": ["allowHighlighting"],
+    "title": "Highlight"
+  };
+  refVal[31] = refVal31;
+  var refVal32 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'id' || key0 == 'label' || key0 == 'layoutVariable' || key0 == 'groupVariable' || key0 == 'edges' || key0 == 'highlight');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            if (data.id === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'id'
+                },
+                message: 'should have required property \'id\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              if (typeof data.id !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.id',
+                  schemaPath: '#/properties/id/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              if (data.label === undefined) {
+                valid1 = false;
+                validate.errors = [{
+                  keyword: 'required',
+                  dataPath: (dataPath || '') + "",
+                  schemaPath: '#/required',
+                  params: {
+                    missingProperty: 'label'
+                  },
+                  message: 'should have required property \'label\''
+                }];
+                return false;
+              } else {
+                var errs_1 = errors;
+                if (typeof data.label !== "string") {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.label',
+                    schemaPath: '#/properties/label/type',
+                    params: {
+                      type: 'string'
+                    },
+                    message: 'should be string'
+                  }];
+                  return false;
+                }
+                var valid1 = errors === errs_1;
+              }
+              if (valid1) {
+                if (data.layoutVariable === undefined) {
+                  valid1 = false;
+                  validate.errors = [{
+                    keyword: 'required',
+                    dataPath: (dataPath || '') + "",
+                    schemaPath: '#/required',
+                    params: {
+                      missingProperty: 'layoutVariable'
+                    },
+                    message: 'should have required property \'layoutVariable\''
+                  }];
+                  return false;
+                } else {
+                  var errs_1 = errors;
+                  if (typeof data.layoutVariable !== "string") {
+                    validate.errors = [{
+                      keyword: 'type',
+                      dataPath: (dataPath || '') + '.layoutVariable',
+                      schemaPath: '#/properties/layoutVariable/type',
+                      params: {
+                        type: 'string'
+                      },
+                      message: 'should be string'
+                    }];
+                    return false;
+                  }
+                  var valid1 = errors === errs_1;
+                }
+                if (valid1) {
+                  if (data.groupVariable === undefined) {
+                    valid1 = true;
+                  } else {
+                    var errs_1 = errors;
+                    if (typeof data.groupVariable !== "string") {
+                      validate.errors = [{
+                        keyword: 'type',
+                        dataPath: (dataPath || '') + '.groupVariable',
+                        schemaPath: '#/properties/groupVariable/type',
+                        params: {
+                          type: 'string'
+                        },
+                        message: 'should be string'
+                      }];
+                      return false;
+                    }
+                    var valid1 = errors === errs_1;
+                  }
+                  if (valid1) {
+                    var data1 = data.edges;
+                    if (data1 === undefined) {
+                      valid1 = true;
+                    } else {
+                      var errs_1 = errors;
+                      var errs_2 = errors;
+                      if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
+                        if (true) {
+                          var errs__2 = errors;
+                          var valid3 = true;
+                          for (var key2 in data1) {
+                            var isAdditional2 = !(false || key2 == 'display' || key2 == 'create');
+                            if (isAdditional2) {
+                              valid3 = false;
+                              validate.errors = [{
+                                keyword: 'additionalProperties',
+                                dataPath: (dataPath || '') + '.edges',
+                                schemaPath: '#/definitions/Edges/additionalProperties',
+                                params: {
+                                  additionalProperty: '' + key2 + ''
+                                },
+                                message: 'should NOT have additional properties'
+                              }];
+                              return false;
+                              break;
+                            }
+                          }
+                          if (valid3) {
+                            var data2 = data1.display;
+                            if (data2 === undefined) {
+                              valid3 = true;
+                            } else {
+                              var errs_3 = errors;
+                              if (Array.isArray(data2)) {
+                                var errs__3 = errors;
+                                var valid3;
+                                for (var i3 = 0; i3 < data2.length; i3++) {
+                                  var errs_4 = errors;
+                                  if (typeof data2[i3] !== "string") {
+                                    validate.errors = [{
+                                      keyword: 'type',
+                                      dataPath: (dataPath || '') + '.edges.display[' + i3 + ']',
+                                      schemaPath: '#/definitions/Edges/properties/display/items/type',
+                                      params: {
+                                        type: 'string'
+                                      },
+                                      message: 'should be string'
+                                    }];
+                                    return false;
+                                  }
+                                  var valid4 = errors === errs_4;
+                                  if (!valid4) break;
+                                }
+                              } else {
+                                validate.errors = [{
+                                  keyword: 'type',
+                                  dataPath: (dataPath || '') + '.edges.display',
+                                  schemaPath: '#/definitions/Edges/properties/display/type',
+                                  params: {
+                                    type: 'array'
+                                  },
+                                  message: 'should be array'
+                                }];
+                                return false;
+                              }
+                              var valid3 = errors === errs_3;
+                            }
+                            if (valid3) {
+                              if (data1.create === undefined) {
+                                valid3 = true;
+                              } else {
+                                var errs_3 = errors;
+                                if (typeof data1.create !== "string") {
+                                  validate.errors = [{
+                                    keyword: 'type',
+                                    dataPath: (dataPath || '') + '.edges.create',
+                                    schemaPath: '#/definitions/Edges/properties/create/type',
+                                    params: {
+                                      type: 'string'
+                                    },
+                                    message: 'should be string'
+                                  }];
+                                  return false;
+                                }
+                                var valid3 = errors === errs_3;
+                              }
+                            }
+                          }
+                        }
+                      } else {
+                        validate.errors = [{
+                          keyword: 'type',
+                          dataPath: (dataPath || '') + '.edges',
+                          schemaPath: '#/definitions/Edges/type',
+                          params: {
+                            type: 'object'
+                          },
+                          message: 'should be object'
+                        }];
+                        return false;
+                      }
+                      var valid2 = errors === errs_2;
+                      var valid1 = errors === errs_1;
+                    }
+                    if (valid1) {
+                      var data1 = data.highlight;
+                      if (data1 === undefined) {
+                        valid1 = true;
+                      } else {
+                        var errs_1 = errors;
+                        var errs_2 = errors;
+                        if (Array.isArray(data1)) {
+                          var errs__2 = errors;
+                          var valid2;
+                          for (var i2 = 0; i2 < data1.length; i2++) {
+                            var errs_3 = errors;
+                            if (typeof data1[i2] !== "string") {
+                              validate.errors = [{
+                                keyword: 'type',
+                                dataPath: (dataPath || '') + '.highlight[' + i2 + ']',
+                                schemaPath: '#/definitions/NarrativeHighlight/items/type',
+                                params: {
+                                  type: 'string'
+                                },
+                                message: 'should be string'
+                              }];
+                              return false;
+                            }
+                            var valid3 = errors === errs_3;
+                            if (!valid3) break;
+                          }
+                        } else {
+                          validate.errors = [{
+                            keyword: 'type',
+                            dataPath: (dataPath || '') + '.highlight',
+                            schemaPath: '#/definitions/NarrativeHighlight/type',
+                            params: {
+                              type: 'array'
+                            },
+                            message: 'should be array'
+                          }];
+                          return false;
+                        }
+                        if (errors === errs_2) {
+                          if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
+                            var errs__2 = errors;
+                            var valid3 = true;
+                            for (var key2 in data1) {
+                              valid3 = false;
+                              validate.errors = [{
+                                keyword: 'additionalProperties',
+                                dataPath: (dataPath || '') + '.highlight',
+                                schemaPath: '#/definitions/NarrativeHighlight/additionalProperties',
+                                params: {
+                                  additionalProperty: '' + key2 + ''
+                                },
+                                message: 'should NOT have additional properties'
+                              }];
+                              return false;
+                              break;
+                            }
+                          }
+                        }
+                        var valid2 = errors === errs_2;
+                        var valid1 = errors === errs_1;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal32.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "label": {
+        "type": "string"
+      },
+      "layoutVariable": {
+        "type": "string"
+      },
+      "groupVariable": {
+        "type": "string"
+      },
+      "edges": {
+        "$ref": "#/definitions/Edges"
+      },
+      "highlight": {
+        "$ref": "#/definitions/NarrativeHighlight"
+      }
+    },
+    "required": ["id", "label", "layoutVariable"],
+    "title": "Preset"
+  };
+  refVal32.errors = null;
+  refVal[32] = refVal32;
+  var refVal33 = {
+    "type": "array",
+    "additionalProperties": false,
+    "items": {
+      "type": "string"
+    },
+    "title": "NarrativeHighlight"
+  };
+  refVal[33] = refVal33;
+  var refVal34 = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "image": {
+        "type": "string"
+      },
+      "concentricCircles": {
+        "type": "integer"
+      },
+      "skewedTowardCenter": {
+        "type": "boolean"
+      }
+    },
+    "required": ["concentricCircles", "skewedTowardCenter"],
+    "title": "Background"
+  };
+  refVal[34] = refVal34;
+  var refVal35 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'sortOrder' || key0 == 'sortableProperties');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            var data1 = data.sortOrder;
+            if (data1 === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'sortOrder'
+                },
+                message: 'should have required property \'sortOrder\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              if (Array.isArray(data1)) {
+                var errs__1 = errors;
+                var valid1;
+                for (var i1 = 0; i1 < data1.length; i1++) {
+                  var errs_2 = errors;
+                  if (!refVal[27](data1[i1], (dataPath || '') + '.sortOrder[' + i1 + ']', data1, i1, rootData)) {
+                    if (vErrors === null) vErrors = refVal[27].errors;
+                    else vErrors = vErrors.concat(refVal[27].errors);
+                    errors = vErrors.length;
+                  }
+                  var valid2 = errors === errs_2;
+                  if (!valid2) break;
+                }
+              } else {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.sortOrder',
+                  schemaPath: '#/properties/sortOrder/type',
+                  params: {
+                    type: 'array'
+                  },
+                  message: 'should be array'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              var data1 = data.sortableProperties;
+              if (data1 === undefined) {
+                valid1 = false;
+                validate.errors = [{
+                  keyword: 'required',
+                  dataPath: (dataPath || '') + "",
+                  schemaPath: '#/required',
+                  params: {
+                    missingProperty: 'sortableProperties'
+                  },
+                  message: 'should have required property \'sortableProperties\''
+                }];
+                return false;
+              } else {
+                var errs_1 = errors;
+                if (Array.isArray(data1)) {
+                  var errs__1 = errors;
+                  var valid1;
+                  for (var i1 = 0; i1 < data1.length; i1++) {
+                    var data2 = data1[i1];
+                    var errs_2 = errors;
+                    var errs_3 = errors;
+                    if ((data2 && typeof data2 === "object" && !Array.isArray(data2))) {
+                      if (true) {
+                        var errs__3 = errors;
+                        var valid4 = true;
+                        for (var key3 in data2) {
+                          var isAdditional3 = !(false || key3 == 'label' || key3 == 'variable');
+                          if (isAdditional3) {
+                            valid4 = false;
+                            validate.errors = [{
+                              keyword: 'additionalProperties',
+                              dataPath: (dataPath || '') + '.sortableProperties[' + i1 + ']',
+                              schemaPath: '#/definitions/Property/additionalProperties',
+                              params: {
+                                additionalProperty: '' + key3 + ''
+                              },
+                              message: 'should NOT have additional properties'
+                            }];
+                            return false;
+                            break;
+                          }
+                        }
+                        if (valid4) {
+                          if (data2.label === undefined) {
+                            valid4 = false;
+                            validate.errors = [{
+                              keyword: 'required',
+                              dataPath: (dataPath || '') + '.sortableProperties[' + i1 + ']',
+                              schemaPath: '#/definitions/Property/required',
+                              params: {
+                                missingProperty: 'label'
+                              },
+                              message: 'should have required property \'label\''
+                            }];
+                            return false;
+                          } else {
+                            var errs_4 = errors;
+                            if (typeof data2.label !== "string") {
+                              validate.errors = [{
+                                keyword: 'type',
+                                dataPath: (dataPath || '') + '.sortableProperties[' + i1 + '].label',
+                                schemaPath: '#/definitions/Property/properties/label/type',
+                                params: {
+                                  type: 'string'
+                                },
+                                message: 'should be string'
+                              }];
+                              return false;
+                            }
+                            var valid4 = errors === errs_4;
+                          }
+                          if (valid4) {
+                            if (data2.variable === undefined) {
+                              valid4 = false;
+                              validate.errors = [{
+                                keyword: 'required',
+                                dataPath: (dataPath || '') + '.sortableProperties[' + i1 + ']',
+                                schemaPath: '#/definitions/Property/required',
+                                params: {
+                                  missingProperty: 'variable'
+                                },
+                                message: 'should have required property \'variable\''
+                              }];
+                              return false;
+                            } else {
+                              var errs_4 = errors;
+                              if (typeof data2.variable !== "string") {
+                                validate.errors = [{
+                                  keyword: 'type',
+                                  dataPath: (dataPath || '') + '.sortableProperties[' + i1 + '].variable',
+                                  schemaPath: '#/definitions/Property/properties/variable/type',
+                                  params: {
+                                    type: 'string'
+                                  },
+                                  message: 'should be string'
+                                }];
+                                return false;
+                              }
+                              var valid4 = errors === errs_4;
+                            }
+                          }
+                        }
+                      }
+                    } else {
+                      validate.errors = [{
+                        keyword: 'type',
+                        dataPath: (dataPath || '') + '.sortableProperties[' + i1 + ']',
+                        schemaPath: '#/definitions/Property/type',
+                        params: {
+                          type: 'object'
+                        },
+                        message: 'should be object'
+                      }];
+                      return false;
+                    }
+                    var valid3 = errors === errs_3;
+                    var valid2 = errors === errs_2;
+                    if (!valid2) break;
+                  }
+                } else {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.sortableProperties',
+                    schemaPath: '#/properties/sortableProperties/type',
+                    params: {
+                      type: 'array'
+                    },
+                    message: 'should be array'
+                  }];
+                  return false;
+                }
+                var valid1 = errors === errs_1;
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal35.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "sortOrder": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/SortOrder"
+        }
+      },
+      "sortableProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Property"
+        }
+      }
+    },
+    "required": ["sortOrder", "sortableProperties"],
+    "title": "SortOptions"
+  };
+  refVal35.errors = null;
+  refVal[35] = refVal35;
+  var refVal36 = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "label": {
+        "type": "string"
+      },
+      "variable": {
+        "type": "string"
+      }
+    },
+    "required": ["label", "variable"],
+    "title": "Property"
+  };
+  refVal[36] = refVal36;
+  var refVal37 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'displayLabel' || key0 == 'additionalProperties');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            if (data.displayLabel === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'displayLabel'
+                },
+                message: 'should have required property \'displayLabel\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              if (typeof data.displayLabel !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.displayLabel',
+                  schemaPath: '#/properties/displayLabel/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              var data1 = data.additionalProperties;
+              if (data1 === undefined) {
+                valid1 = true;
+              } else {
+                var errs_1 = errors;
+                if (Array.isArray(data1)) {
+                  var errs__1 = errors;
+                  var valid1;
+                  for (var i1 = 0; i1 < data1.length; i1++) {
+                    var data2 = data1[i1];
+                    var errs_2 = errors;
+                    var errs_3 = errors;
+                    if ((data2 && typeof data2 === "object" && !Array.isArray(data2))) {
+                      if (true) {
+                        var errs__3 = errors;
+                        var valid4 = true;
+                        for (var key3 in data2) {
+                          var isAdditional3 = !(false || key3 == 'label' || key3 == 'variable');
+                          if (isAdditional3) {
+                            valid4 = false;
+                            validate.errors = [{
+                              keyword: 'additionalProperties',
+                              dataPath: (dataPath || '') + '.additionalProperties[' + i1 + ']',
+                              schemaPath: '#/definitions/Property/additionalProperties',
+                              params: {
+                                additionalProperty: '' + key3 + ''
+                              },
+                              message: 'should NOT have additional properties'
+                            }];
+                            return false;
+                            break;
+                          }
+                        }
+                        if (valid4) {
+                          if (data2.label === undefined) {
+                            valid4 = false;
+                            validate.errors = [{
+                              keyword: 'required',
+                              dataPath: (dataPath || '') + '.additionalProperties[' + i1 + ']',
+                              schemaPath: '#/definitions/Property/required',
+                              params: {
+                                missingProperty: 'label'
+                              },
+                              message: 'should have required property \'label\''
+                            }];
+                            return false;
+                          } else {
+                            var errs_4 = errors;
+                            if (typeof data2.label !== "string") {
+                              validate.errors = [{
+                                keyword: 'type',
+                                dataPath: (dataPath || '') + '.additionalProperties[' + i1 + '].label',
+                                schemaPath: '#/definitions/Property/properties/label/type',
+                                params: {
+                                  type: 'string'
+                                },
+                                message: 'should be string'
+                              }];
+                              return false;
+                            }
+                            var valid4 = errors === errs_4;
+                          }
+                          if (valid4) {
+                            if (data2.variable === undefined) {
+                              valid4 = false;
+                              validate.errors = [{
+                                keyword: 'required',
+                                dataPath: (dataPath || '') + '.additionalProperties[' + i1 + ']',
+                                schemaPath: '#/definitions/Property/required',
+                                params: {
+                                  missingProperty: 'variable'
+                                },
+                                message: 'should have required property \'variable\''
+                              }];
+                              return false;
+                            } else {
+                              var errs_4 = errors;
+                              if (typeof data2.variable !== "string") {
+                                validate.errors = [{
+                                  keyword: 'type',
+                                  dataPath: (dataPath || '') + '.additionalProperties[' + i1 + '].variable',
+                                  schemaPath: '#/definitions/Property/properties/variable/type',
+                                  params: {
+                                    type: 'string'
+                                  },
+                                  message: 'should be string'
+                                }];
+                                return false;
+                              }
+                              var valid4 = errors === errs_4;
+                            }
+                          }
+                        }
+                      }
+                    } else {
+                      validate.errors = [{
+                        keyword: 'type',
+                        dataPath: (dataPath || '') + '.additionalProperties[' + i1 + ']',
+                        schemaPath: '#/definitions/Property/type',
+                        params: {
+                          type: 'object'
+                        },
+                        message: 'should be object'
+                      }];
+                      return false;
+                    }
+                    var valid3 = errors === errs_3;
+                    var valid2 = errors === errs_2;
+                    if (!valid2) break;
+                  }
+                } else {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.additionalProperties',
+                    schemaPath: '#/properties/additionalProperties/type',
+                    params: {
+                      type: 'array'
+                    },
+                    message: 'should be array'
+                  }];
+                  return false;
+                }
+                var valid1 = errors === errs_1;
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal37.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "displayLabel": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Property"
+        }
+      }
+    },
+    "required": ["displayLabel"],
+    "title": "CardOptions"
+  };
+  refVal37.errors = null;
+  refVal[37] = refVal37;
+  var refVal38 = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "fuzziness": {
+        "type": "number"
+      },
+      "matchProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "required": ["fuzziness", "matchProperties"],
+    "title": "SearchOptions"
+  };
+  refVal[38] = refVal38;
+  var refVal39 = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "freeDraw": {
+        "type": "boolean"
+      },
+      "featureNode": {
+        "type": "boolean"
+      },
+      "allowRepositioning": {
+        "type": "boolean"
+      }
+    },
+    "required": [],
+    "title": "Behaviours"
+  };
+  refVal[39] = refVal39;
+  var refVal40 = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "type": {
+        "type": "string",
+        "enum": ["text", "asset"]
+      },
+      "content": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "size": {
+        "type": "string"
+      },
+      "loop": {
+        "type": "boolean"
+      }
+    },
+    "required": ["content", "id", "type"],
+    "title": "Item"
+  };
+  refVal[40] = refVal40;
+  var refVal41 = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "title": {
+        "type": "string"
+      },
+      "text": {
+        "type": "string"
+      }
+    },
+    "required": ["title", "text"]
+  };
+  refVal[41] = refVal41;
+  var refVal42 = (function() {
+    var pattern0 = new RegExp('.+');
+    return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+      'use strict';
+      var vErrors = null;
+      var errors = 0;
+      if (rootData === undefined) rootData = data;
+      if ((data && typeof data === "object" && !Array.isArray(data))) {
+        if (true) {
+          var errs__0 = errors;
+          var valid1 = true;
+          for (var key0 in data) {
+            var isAdditional0 = !(false || key0 == 'action' || key0 == 'filter');
+            if (isAdditional0) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'additionalProperties',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/additionalProperties',
+                params: {
+                  additionalProperty: '' + key0 + ''
+                },
+                message: 'should NOT have additional properties'
+              }];
+              return false;
+              break;
+            }
+          }
+          if (valid1) {
+            var data1 = data.action;
+            if (data1 === undefined) {
+              valid1 = false;
+              validate.errors = [{
+                keyword: 'required',
+                dataPath: (dataPath || '') + "",
+                schemaPath: '#/required',
+                params: {
+                  missingProperty: 'action'
+                },
+                message: 'should have required property \'action\''
+              }];
+              return false;
+            } else {
+              var errs_1 = errors;
+              if (typeof data1 !== "string") {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.action',
+                  schemaPath: '#/properties/action/type',
+                  params: {
+                    type: 'string'
+                  },
+                  message: 'should be string'
+                }];
+                return false;
+              }
+              var schema1 = validate.schema.properties.action.enum;
+              var valid1;
+              valid1 = false;
+              for (var i1 = 0; i1 < schema1.length; i1++)
+                if (equal(data1, schema1[i1])) {
+                  valid1 = true;
+                  break;
+                } if (!valid1) {
+                validate.errors = [{
+                  keyword: 'enum',
+                  dataPath: (dataPath || '') + '.action',
+                  schemaPath: '#/properties/action/enum',
+                  params: {
+                    allowedValues: schema1
+                  },
+                  message: 'should be equal to one of the allowed values'
+                }];
+                return false;
+              }
+              var valid1 = errors === errs_1;
+            }
+            if (valid1) {
+              if (data.filter === undefined) {
+                valid1 = false;
+                validate.errors = [{
+                  keyword: 'required',
+                  dataPath: (dataPath || '') + "",
+                  schemaPath: '#/required',
+                  params: {
+                    missingProperty: 'filter'
+                  },
+                  message: 'should have required property \'filter\''
+                }];
+                return false;
+              } else {
+                var errs_1 = errors;
+                if (!refVal[21](data.filter, (dataPath || '') + '.filter', data, 'filter', rootData)) {
+                  if (vErrors === null) vErrors = refVal[21].errors;
+                  else vErrors = vErrors.concat(refVal[21].errors);
+                  errors = vErrors.length;
+                }
+                var valid1 = errors === errs_1;
+              }
+            }
+          }
+        }
+      } else {
+        validate.errors = [{
+          keyword: 'type',
+          dataPath: (dataPath || '') + "",
+          schemaPath: '#/type',
+          params: {
+            type: 'object'
+          },
+          message: 'should be object'
+        }];
+        return false;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+  })();
+  refVal42.schema = {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "action": {
+        "type": "string",
+        "enum": ["SHOW", "SKIP"]
+      },
+      "filter": {
+        "$ref": "#/definitions/Filter"
+      }
+    },
+    "required": ["action", "filter"],
+    "title": "SkipLogic"
+  };
+  refVal42.errors = null;
+  refVal[42] = refVal42;
+  return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
+    'use strict';
+    var vErrors = null;
+    var errors = 0;
+    if (rootData === undefined) rootData = data;
+    if (!refVal1(data, (dataPath || ''), parentData, parentDataProperty, rootData)) {
+      if (vErrors === null) vErrors = refVal1.errors;
+      else vErrors = vErrors.concat(refVal1.errors);
+      errors = vErrors.length;
+    }
+    validate.errors = vErrors;
+    return errors === 0;
+  };
+})();
+validate.schema = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Protocol",
+  "definitions": {
+    "Protocol": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "lastModified": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaVersion": {
+          "type": "string"
+        },
+        "codebook": {
+          "$ref": "#/definitions/codebook"
+        },
+        "assetManifest": {
+          "$ref": "#/definitions/AssetManifest"
+        },
+        "stages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Stage"
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["name", "stages", "codebook"],
+      "title": "Protocol"
+    },
+    "AssetManifest": {
+      "type": "object",
+      "title": "AssetManifest"
+    },
+    "Form": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Field"
+          }
+        }
+      },
+      "required": ["fields"],
+      "title": "Form"
+    },
+    "Field": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "variable": {
+          "type": "string"
+        },
+        "component": {
+          "type": "string",
+          "enum": ["CheckboxGroup", "Number", "RadioGroup", "Text", "Toggle", "ToggleButtonGroup"]
+        },
+        "prompt": {
+          "type": "string"
+        },
+        "validation": {
+          "$ref": "#/definitions/Validation"
+        }
+      },
+      "required": ["component", "variable", "prompt"],
+      "title": "Field"
+    },
+    "Stage": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["Narrative", "AlterForm", "AlterEdgeForm", "EgoForm", "NameGenerator", "NameGeneratorQuickAdd", "NameGeneratorList", "NameGeneratorAutoComplete", "Sociogram", "Information", "OrdinalBin", "CategoricalBin"]
+        },
+        "label": {
+          "type": "string"
+        },
+        "form": {
+          "$ref": "#/definitions/Form"
+        },
+        "quickAdd": {
+          "type": ["string", "null"]
+        },
+        "dataSource": {
+          "type": ["string", "null"]
+        },
+        "subject": {
+          "$ref": "#/definitions/Subject"
+        },
+        "panels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Panel"
+          }
+        },
+        "prompts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Prompt"
+          },
+          "minItems": 1
+        },
+        "presets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Preset"
+          },
+          "minItems": 1
+        },
+        "background": {
+          "type": "object",
+          "items": {
+            "$ref": "#/definitions/Background"
+          },
+          "minItems": 1
+        },
+        "sortOptions": {
+          "type": "object",
+          "items": {
+            "$ref": "#/definitions/SortOptions"
+          }
+        },
+        "cardOptions": {
+          "type": "object",
+          "items": {
+            "$ref": "#/definitions/CardOptions"
+          }
+        },
+        "searchOptions": {
+          "type": "object",
+          "items": {
+            "$ref": "#/definitions/SearchOptions"
+          }
+        },
+        "behaviours": {
+          "type": "object",
+          "items": {
+            "$ref": "#/definitions/Behaviours"
+          },
+          "minItems": 1
+        },
+        "showExistingNodes": {
+          "type": "boolean"
+        },
+        "title": {
+          "type": "string"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Item"
+          }
+        },
+        "introductionPanel": {
+          "$ref": "#/definitions/IntroductionPanel"
+        },
+        "skipLogic": {
+          "$ref": "#/definitions/SkipLogic"
+        }
+      },
+      "required": ["id", "label", "type"],
+      "title": "Interface",
+      "anyOf": [{
+        "properties": {
+          "type": {
+            "const": "EgoForm"
+          }
+        },
+        "required": ["form", "introductionPanel"]
+      }, {
+        "properties": {
+          "type": {
+            "const": "AlterForm"
+          }
+        },
+        "required": ["form", "introductionPanel"]
+      }, {
+        "properties": {
+          "type": {
+            "const": "AlterEdgeForm"
+          }
+        },
+        "required": ["form", "introductionPanel"]
+      }, {
+        "properties": {
+          "type": {
+            "const": "Information"
+          }
+        },
+        "required": ["items"]
+      }, {
+        "properties": {
+          "type": {
+            "const": "Narrative"
+          }
+        },
+        "required": ["presets", "background", "behaviours"]
+      }, {
+        "properties": {
+          "type": {
+            "enum": ["NameGenerator", "NameGeneratorQuickAdd", "NameGeneratorList", "NameGeneratorAutoComplete", "Sociogram", "OrdinalBin", "CategoricalBin"]
+          }
+        },
+        "required": ["prompts"]
+      }]
+    },
+    "Item": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["text", "asset"]
+        },
+        "content": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "size": {
+          "type": "string"
+        },
+        "loop": {
+          "type": "boolean"
+        }
+      },
+      "required": ["content", "id", "type"],
+      "title": "Item"
+    },
+    "IntroductionPanel": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": ["title", "text"]
+    },
+    "Panel": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "filter": {
+          "$ref": "#/definitions/Filter"
+        },
+        "dataSource": {
+          "type": ["string", "null"]
+        }
+      },
+      "required": ["id", "title", "dataSource"],
+      "title": "Panel"
+    },
+    "Filter": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "join": {
+          "type": "string",
+          "enum": ["OR", "AND"]
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Rule"
+          }
+        }
+      },
+      "title": "Filter"
+    },
+    "Rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["alter", "ego", "edge"]
+        },
+        "id": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/Options"
+        }
+      },
+      "required": ["id", "options", "type"],
+      "title": "Rule"
+    },
+    "Options": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "attribute": {
+          "type": "string"
+        },
+        "operator": {
+          "type": "string",
+          "enum": ["EXISTS", "NOT_EXISTS", "EXACTLY", "NOT", "GREATER_THAN", "GREATER_THAN_OR_EQUAL", "LESS_THAN", "LESS_THAN_OR_EQUAL"]
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": ["operator"],
+      "title": "Rule Options",
+      "allOf": [{
+        "if": {
+          "properties": {
+            "operator": {
+              "enum": ["EXACTLY", "NOT", "GREATER_THAN", "GREATER_THAN_OR_EQUAL", "LESS_THAN", "LESS_THAN_OR_EQUAL"]
+            }
+          }
+        },
+        "then": {
+          "required": ["value"]
+        }
+      }]
+    },
+    "Prompt": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "additionalAttributes": {
+          "$ref": "#/definitions/AdditionalAttributes"
+        },
+        "variable": {
+          "type": "string"
+        },
+        "bucketSortOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SortOrder"
+          }
+        },
+        "binSortOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SortOrder"
+          }
+        },
+        "sortOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SortOrder"
+          }
+        },
+        "color": {
+          "type": "string"
+        },
+        "layout": {
+          "$ref": "#/definitions/Layout"
+        },
+        "edges": {
+          "$ref": "#/definitions/Edges"
+        },
+        "highlight": {
+          "$ref": "#/definitions/Highlight"
+        }
+      },
+      "required": ["id", "text"],
+      "title": "Prompt"
+    },
+    "Preset": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "layoutVariable": {
+          "type": "string"
+        },
+        "groupVariable": {
+          "type": "string"
+        },
+        "edges": {
+          "$ref": "#/definitions/Edges"
+        },
+        "highlight": {
+          "$ref": "#/definitions/NarrativeHighlight"
+        }
+      },
+      "required": ["id", "label", "layoutVariable"],
+      "title": "Preset"
+    },
+    "Behaviours": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "freeDraw": {
+          "type": "boolean"
+        },
+        "featureNode": {
+          "type": "boolean"
+        },
+        "allowRepositioning": {
+          "type": "boolean"
+        }
+      },
+      "required": [],
+      "title": "Behaviours"
+    },
+    "AdditionalAttributes": {
+      "type": "array",
+      "title": "AdditionalAttributes",
+      "items": {
+        "$ref": "#/definitions/AdditionalAttribute"
+      }
+    },
+    "AdditionalAttribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "variable": {
+          "type": "string"
+        },
+        "value": {
+          "type": ["integer", "string", "array", "boolean"]
+        }
+      },
+      "required": ["variable", "value"],
+      "title": "AdditionalAttribute"
+    },
+    "Background": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "type": "string"
+        },
+        "concentricCircles": {
+          "type": "integer"
+        },
+        "skewedTowardCenter": {
+          "type": "boolean"
+        }
+      },
+      "required": ["concentricCircles", "skewedTowardCenter"],
+      "title": "Background"
+    },
+    "SortOrder": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "property": {
+          "type": "string"
+        },
+        "direction": {
+          "$ref": "#/definitions/Direction"
+        }
+      },
+      "required": ["direction", "property"],
+      "title": "SortOrder"
+    },
+    "CardOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "displayLabel": {
+          "type": "string"
+        },
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Property"
+          }
+        }
+      },
+      "required": ["displayLabel"],
+      "title": "CardOptions"
+    },
+    "Property": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "variable": {
+          "type": "string"
+        }
+      },
+      "required": ["label", "variable"],
+      "title": "Property"
+    },
+    "Edges": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "display": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "create": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Edges"
+    },
+    "NarrativeHighlight": {
+      "type": "array",
+      "additionalProperties": false,
+      "items": {
+        "type": "string"
+      },
+      "title": "NarrativeHighlight"
+    },
+    "Highlight": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "variable": {
+          "type": "string"
+        },
+        "allowHighlighting": {
+          "type": "boolean"
+        }
+      },
+      "required": ["allowHighlighting"],
+      "title": "Highlight"
+    },
+    "Layout": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "layoutVariable": {
+          "type": "string"
+        },
+        "allowPositioning": {
+          "type": "boolean"
+        }
+      },
+      "required": ["layoutVariable"],
+      "title": "Layout"
+    },
+    "SearchOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "fuzziness": {
+          "type": "number"
+        },
+        "matchProperties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["fuzziness", "matchProperties"],
+      "title": "SearchOptions"
+    },
+    "SortOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sortOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SortOrder"
+          }
+        },
+        "sortableProperties": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Property"
+          }
+        }
+      },
+      "required": ["sortOrder", "sortableProperties"],
+      "title": "SortOptions"
+    },
+    "Subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "entity": {
+          "$ref": "#/definitions/Entity"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": ["entity", "type"],
+      "title": "Subject"
+    },
+    "SkipLogic": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": ["SHOW", "SKIP"]
+        },
+        "filter": {
+          "$ref": "#/definitions/Filter"
+        }
+      },
+      "required": ["action", "filter"],
+      "title": "SkipLogic"
+    },
+    "codebook": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "node": {
+          "$ref": "#/definitions/Node"
+        },
+        "edge": {
+          "$ref": "#/definitions/Edge"
+        },
+        "ego": {
+          "$ref": "#/definitions/Ego"
+        }
+      },
+      "required": [],
+      "title": "codebook"
+    },
+    "Edge": {
+      "type": "object",
+      "additionalProperties": false,
+      "title": "Edge",
+      "patternProperties": {
+        ".+": {
+          "$ref": "#/definitions/EdgeTypeDef"
+        }
+      }
+    },
+    "EdgeTypeDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "variables": {
+          "$ref": "#/definitions/Variables"
+        }
+      },
+      "required": ["name", "color"],
+      "title": "EdgeTypeDef"
+    },
+    "Variables": {
+      "type": "object",
+      "additionalProperties": false,
+      "title": "Variables",
+      "patternProperties": {
+        ".+": {
+          "$ref": "#/definitions/Variable"
+        }
+      }
+    },
+    "Variable": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["boolean", "text", "number", "datetime", "ordinal", "categorical", "layout", "location"]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OptionElement"
+          }
+        }
+      },
+      "required": ["type", "name"],
+      "title": "Variable"
+    },
+    "OptionClass": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/definitions/Value"
+        }
+      },
+      "required": ["label", "value"],
+      "title": "OptionClass"
+    },
+    "Validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "requiredAcceptsNull": {
+          "type": "boolean"
+        },
+        "minLength": {
+          "type": "integer"
+        },
+        "maxLength": {
+          "type": "integer"
+        },
+        "minValue": {
+          "type": "integer"
+        },
+        "maxValue": {
+          "type": "integer"
+        },
+        "minSelected": {
+          "type": "integer"
+        },
+        "maxSelected": {
+          "type": "integer"
+        }
+      },
+      "title": "Validation"
+    },
+    "Node": {
+      "type": "object",
+      "additionalProperties": false,
+      "title": "Node",
+      "patternProperties": {
+        ".+": {
+          "$ref": "#/definitions/NodeTypeDef"
+        }
+      }
+    },
+    "NodeTypeDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "displayVariable": {
+          "type": "string"
+        },
+        "iconVariant": {
+          "type": "string"
+        },
+        "variables": {
+          "$ref": "#/definitions/Variables"
+        },
+        "color": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "variables", "color"],
+      "title": "NodeTypeDef"
+    },
+    "Ego": {
+      "label": "string",
+      "color": "string",
+      "title": "Ego",
+      "variables": {
+        "$ref": "#/definitions/Variables"
+      }
+    },
+    "OptionElement": {
+      "anyOf": [{
+        "$ref": "#/definitions/OptionClass"
+      }, {
+        "type": "integer"
+      }, {
+        "type": "string"
+      }],
+      "title": "Variable Option"
+    },
+    "Value": {
+      "anyOf": [{
+        "type": "integer"
+      }, {
+        "type": "string"
+      }],
+      "title": "Value"
+    },
+    "Entity": {
+      "type": "string",
+      "enum": ["edge", "node", "ego"],
+      "title": "Entity"
+    },
+    "Direction": {
+      "type": "string",
+      "enum": ["desc", "asc"],
+      "title": "Direction"
+    }
+  }
+};
+validate.errors = null;
+module.exports = validate;

--- a/scripts/build-schemas.js
+++ b/scripts/build-schemas.js
@@ -1,0 +1,60 @@
+const fs = require('fs-extra');
+const path = require('path');
+const Ajv = require('ajv');
+const pack = require('ajv-pack');
+
+const ajv = new Ajv({ sourceCode: true });
+ajv.addFormat('integer', /\d+/);
+
+const isJsonFile = fileName =>
+  path.extname(fileName) === '.json';
+
+const getSchemaName = schemaFileName =>
+  path.basename(schemaFileName, '.json');
+
+// get schemas,
+const getSchemas = directory =>
+  fs.readdir(directory)
+    .then(
+      files =>
+        files
+          .filter(isJsonFile)
+          .map(getSchemaName),
+    );
+
+const generateModuleIndex = (schemas) => {
+  const formatRequire = (schemaName) => {
+    const relativeModulePath = path.join(`./${schemaName}.js`);
+    return `const ${schemaName} = require('./${relativeModulePath}');\n`;
+  };
+
+  const schemaRequires = schemas.map(formatRequire).join('\n');
+  const schemaExports = schemas.join(', ');
+
+  return `${schemaRequires}\nmodule.exports = { ${schemaExports} };\r\n`;
+};
+
+const buildSchemas = async () => {
+  const schemasDirectory = path.resolve('schemas');
+
+  const schemas = await getSchemas(schemasDirectory);
+
+  schemas.forEach(async (schemaName) => {
+    const schemaPath = path.join(schemasDirectory, `${schemaName}.json`);
+    const modulePath = path.join(schemasDirectory, `${schemaName}.js`);
+
+    const schema = await fs.readJson(schemaPath);
+    const validate = ajv.compile(schema);
+    const moduleCode = pack(ajv, validate);
+
+    await fs.writeFile(modulePath, moduleCode);
+
+    console.log(schemaName, 'done');
+  });
+
+  const moduleIndexPath = path.join(schemasDirectory, 'index.js');
+  const moduleIndex = generateModuleIndex(schemas);
+  await fs.writeFile(moduleIndexPath, moduleIndex);
+};
+
+buildSchemas();

--- a/validation/validateSchema.js
+++ b/validation/validateSchema.js
@@ -1,17 +1,9 @@
-const Ajv = require('ajv');
-
 const { v1 } = require('../schemas/');
 
 /**
  * Statically validate the protocol based on its JSON schema
  */
-const validateSchema = (protocol, schema = v1) => {
-  const ajv = new Ajv({
-    allErrors: true,
-  });
-  ajv.addFormat('integer', /\d+/);
-
-  const validate = ajv.compile(schema);
+const validateSchema = (protocol, validate = v1) => {
   validate(protocol, 'Protocol');
   return validate.errors || [];
 };


### PR DESCRIPTION
This adds capability to pre-compile validators so that they can be used accross the apps without on the fly compilation which involves an unsafe eval.

- Adds new script: `npm run build`, which compiles each schema and generates an index file
- Updates `validateSchema` to use these precompiled versions.