### PR TITLE
fix validator recursion

### DIFF
--- a/validation/Validator.js
+++ b/validation/Validator.js
@@ -175,7 +175,12 @@ class Validator {
       });
     } else if (fragment && typeof fragment === 'object') {
       Object.entries(fragment).forEach(([key, val]) => {
-        this.traverse(val, [...keypath, key], stageSubject);
+        if (val !== undefined) {
+          this.traverse(val, [...keypath, key], stageSubject);
+        } else {
+          // don't traverse on undefined
+          debugLog('-', keypathString(keypath));
+        }
       });
     } else { // Leaf node
       debugLog('-', keypathString(keypath));


### PR DESCRIPTION
This fixes an issue with Validator, where it exhausts the stack when an object in the protocol has an `undefined` value.