### PR TITLE
make behaviours optional

### DIFF
--- a/schemas/v1.js
+++ b/schemas/v1.js
@@ -3132,20 +3132,6 @@ var validate = (function() {
                   else vErrors.push(err);
                   errors++;
                 }
-                if (data.behaviours === undefined) {
-                  var err = {
-                    keyword: 'required',
-                    dataPath: (dataPath || '') + "",
-                    schemaPath: '#/anyOf/4/required',
-                    params: {
-                      missingProperty: 'behaviours'
-                    },
-                    message: 'should have required property \'behaviours\''
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
                 var errs__1 = errors;
                 var valid2 = true;
                 if (data.type !== undefined) {
@@ -3378,7 +3364,7 @@ var validate = (function() {
           "const": "Narrative"
         }
       },
-      "required": ["presets", "background", "behaviours"]
+      "required": ["presets", "background"]
     }, {
       "properties": {
         "type": {
@@ -6765,7 +6751,7 @@ validate.schema = {
             "const": "Narrative"
           }
         },
-        "required": ["presets", "background", "behaviours"]
+        "required": ["presets", "background"]
       }, {
         "properties": {
           "type": {

--- a/schemas/v1.json
+++ b/schemas/v1.json
@@ -247,8 +247,7 @@
           },
           "required": [
             "presets",
-            "background",
-            "behaviours"
+            "background"
           ]
         },
         {


### PR DESCRIPTION
This makes `behaviours` optional for protocol validation, fixing an error for narrative interface in Architect when no special behaviors are specified. NC does not require `behaviours`.