### PR TITLE
Feature/improve migrations

### DIFF
--- a/migrations/__tests__/migrateProtocol.test.js
+++ b/migrations/__tests__/migrateProtocol.test.js
@@ -13,7 +13,7 @@ jest.mock('../migrations');
 migrations.push({ version: '1', migration: jest.fn(protocol => protocol) });
 migrations.push({ version: '2', migration: jest.fn(protocol => ({ ...protocol, foo: 'bar', bazz: 'buzz' })) });
 migrations.push({ version: '3', migration: jest.fn(({ foo, ...protocol }) => ({ ...protocol, fizz: 'pop' })) });
-migrations.push({ version: '4', migration: jest.fn(() => undefined) });
+migrations.push({ version: '4', migration: null });
 migrations.push({ version: '5', migration: jest.fn(protocol => protocol) });
 
 const mockProtocol = {

--- a/migrations/__tests__/migrateProtocol.test.js
+++ b/migrations/__tests__/migrateProtocol.test.js
@@ -10,11 +10,14 @@ jest.mock('../migrations');
  * Migrations are run in the order that they are defined relative to one another
  * e.g. 1 -> 3, will run 1 -> 2 -> 3
  */
+
+const specificMigrationError = new Error('whoops');
 migrations.push({ version: '1', migration: jest.fn(protocol => protocol) });
 migrations.push({ version: '2', migration: jest.fn(protocol => ({ ...protocol, foo: 'bar', bazz: 'buzz' })) });
 migrations.push({ version: '3', migration: jest.fn(({ foo, ...protocol }) => ({ ...protocol, fizz: 'pop' })) });
 migrations.push({ version: '4', migration: null });
 migrations.push({ version: '5', migration: jest.fn(protocol => protocol) });
+migrations.push({ version: '6', migration: jest.fn(() => { throw specificMigrationError; }) });
 
 const mockProtocol = {
   schemaVersion: '1',
@@ -23,23 +26,15 @@ const mockProtocol = {
 describe('migrateProtocol', () => {
   beforeEach(() => {
     // reset mocks
-    migrations.forEach(({ migration }) => migration.mockClear());
+    migrations.forEach(({ migration }) => migration && migration.mockClear());
   });
 
   it('runs migrations from protocol schema version to target schema version', () => {
-    migrateProtocol(mockProtocol, '3');
+    migrateProtocol(mockProtocol, '2');
 
     expect(migrations[0].migration.mock.calls.length).toBe(0); // version: '1'
     expect(migrations[1].migration.mock.calls.length).toBe(1); // version: '2'
-    expect(migrations[2].migration.mock.calls.length).toBe(1); // version: '3'
-    expect(migrations[3].migration.mock.calls.length).toBe(0); // version: '4'
-  });
-
-  it('runs migrations from protocol schema version to target schema version', () => {
-    migrateProtocol({ schemaVersion: '4' }, '5');
-
-    expect(migrations[3].migration.mock.calls.length).toBe(0); // version: '4'
-    expect(migrations[4].migration.mock.calls.length).toBe(1); // version: '5'
+    expect(migrations[2].migration.mock.calls.length).toBe(0); // version: '3'
   });
 
   it('migrations transform protocol successively', () => {
@@ -66,5 +61,13 @@ describe('migrateProtocol', () => {
     expect(() => {
       migrateProtocol(mockProtocol, '4');
     }).toThrow(errors.MigrationNotPossibleError);
+  });
+
+  it('throws a generic MigrationError error migration step throws an error', () => {
+    expect(() => {
+      migrateProtocol({
+        schemaVersion: '5',
+      }, '6');
+    }).toThrow(/Migration step failed/);
   });
 });

--- a/migrations/getMigrationPath.js
+++ b/migrations/getMigrationPath.js
@@ -1,0 +1,35 @@
+const migrations = require('./migrations');
+const errors = require('./errors');
+
+const matchVersion = targetVersion =>
+  ({ version }) =>
+    version === targetVersion;
+
+const isMigrationPathValid = path =>
+  !path.some(({ migration }) => !migration);
+
+const getMigrationPath = (protocol, targetSchemaVersion) => {
+  const protocolSchemaVersion = protocol.schemaVersion;
+
+  const protocolMigrationIndex = migrations.findIndex(matchVersion(protocolSchemaVersion));
+  const targetMigrationIndex = migrations.findIndex(matchVersion(targetSchemaVersion));
+
+  if (protocolMigrationIndex === -1) {
+    throw errors.CurrentProtocolNotFoundError;
+  }
+
+  if (targetMigrationIndex === -1) {
+    throw errors.TargetProtocolNotFoundError;
+  }
+
+  // Get migration steps between versions
+  const migrationPath = migrations.slice(protocolMigrationIndex + 1, targetMigrationIndex + 1);
+
+  if (!isMigrationPathValid(migrationPath)) {
+    throw errors.MigrationNotPossibleError;
+  }
+
+  return migrationPath;
+};
+
+module.exports = getMigrationPath;

--- a/migrations/hasMigrationPath.js
+++ b/migrations/hasMigrationPath.js
@@ -3,7 +3,7 @@ const getMigrationPath = require('./getMigrationPath');
 const hasMigrationPath = (protocol, targetSchemaVersion) => {
   try {
     getMigrationPath(protocol, targetSchemaVersion);
-  } catch(e) {
+  } catch (e) {
     return false;
   }
 

--- a/migrations/hasMigrationPath.js
+++ b/migrations/hasMigrationPath.js
@@ -1,0 +1,13 @@
+const getMigrationPath = require('./getMigrationPath');
+
+const hasMigrationPath = (protocol, targetSchemaVersion) => {
+  try {
+    getMigrationPath(protocol, targetSchemaVersion);
+  } catch(e) {
+    return false;
+  }
+
+  return true;
+};
+
+module.exports = hasMigrationPath;

--- a/migrations/migrateProtocol.js
+++ b/migrations/migrateProtocol.js
@@ -1,7 +1,13 @@
 const getMigrationPath = require('./getMigrationPath');
 
-const migrateStep = (protocol, { migration }) =>
-  migration(protocol);
+const migrateStep = (protocol, { version, migration }) => {
+  try {
+    return migration(protocol);
+  } catch (e) {
+    e.message = `Migration step failed: { version: ${JSON.stringify(version)} }`;
+    throw e;
+  }
+};
 
 const migrateProtocol = (protocol, targetSchemaVersion) => {
   // Get migration steps between versions

--- a/migrations/migrateProtocol.js
+++ b/migrations/migrateProtocol.js
@@ -1,32 +1,11 @@
-const migrations = require('./migrations');
-const errors = require('./errors');
+const getMigrationPath = require('./getMigrationPath');
 
-const matchVersion = targetVersion =>
-  ({ version }) =>
-    version === targetVersion;
-
-const migrateStep = (protocol, { migration }) => {
-  if (!migration) { throw errors.MigrationNotPossibleError; }
-
-  return migration(protocol);
-};
+const migrateStep = (protocol, { migration }) =>
+  migration(protocol);
 
 const migrateProtocol = (protocol, targetSchemaVersion) => {
-  const protocolSchemaVersion = protocol.schemaVersion;
-
-  const protocolMigrationIndex = migrations.findIndex(matchVersion(protocolSchemaVersion));
-  const targetMigrationIndex = migrations.findIndex(matchVersion(targetSchemaVersion));
-
-  if (protocolMigrationIndex === -1) {
-    throw errors.CurrentProtocolNotFoundError;
-  }
-
-  if (targetMigrationIndex === -1) {
-    throw errors.TargetProtocolNotFoundError;
-  }
-
   // Get migration steps between versions
-  const migrationPath = migrations.slice(protocolMigrationIndex + 1, targetMigrationIndex + 1);
+  const migrationPath = getMigrationPath(protocol, targetSchemaVersion);
 
   // Perform migration
   const updatedProtocol = migrationPath.reduce(migrateStep, protocol);

--- a/migrations/migrateProtocol.js
+++ b/migrations/migrateProtocol.js
@@ -6,9 +6,9 @@ const matchVersion = targetVersion =>
     version === targetVersion;
 
 const migrateStep = (protocol, { migration }) => {
-  const updatedProtocol = migration(protocol);
-  if (updatedProtocol === undefined) { throw errors.MigrationNotPossibleError; }
-  return updatedProtocol;
+  if (!migration) { throw errors.MigrationNotPossibleError; }
+
+  return migration(protocol);
 };
 
 const migrateProtocol = (protocol, targetSchemaVersion) => {

--- a/migrations/migrations.js
+++ b/migrations/migrations.js
@@ -1,6 +1,7 @@
 const migrations = [
   { version: '1.0.0', migration: noop => noop },
   { version: '1', migration: noop => noop },
+  { version: '2', migration: noop => noop },
 ];
 
 module.exports = migrations;

--- a/migrations/migrations.js
+++ b/migrations/migrations.js
@@ -1,7 +1,7 @@
 const migrations = [
-  { version: '1.0.0', migration: noop => noop },
-  { version: '1', migration: noop => noop },
-  { version: '2', migration: noop => noop },
+  { version: '1.0.0', migration: protocol => protocol },
+  { version: '1', migration: protocol => protocol },
+  { version: '2', migration: protocol => protocol },
 ];
 
 module.exports = migrations;


### PR DESCRIPTION
- Change how blocked upgrade paths are declared
  ```js
  // In order to indicate that the current version cannot be upgraded to:
  // previous implementation
  { migration: () => undefined }
  // new implementation
  { migration: null }
  ```
- Add a migration step for version 2. Even noop migrations need to be listed, so the migration tool can find steps between version numbers.
- Separate out code for finding migration paths, so we can check for upgrade paths before attemping a migration.
- Adds error catch for migration steps.

Required for: https://github.com/codaco/Architect/pull/567