### PR TITLE
Abstract version comparison from Architect to protocol validation migrations

### DIFF
--- a/migrations/__tests__/migrateProtocol.test.js
+++ b/migrations/__tests__/migrateProtocol.test.js
@@ -2,7 +2,6 @@
 
 const migrateProtocol = require('../migrateProtocol');
 const migrations = require('../migrations');
-const errors = require('../errors');
 
 jest.mock('../migrations');
 
@@ -46,21 +45,29 @@ describe('migrateProtocol', () => {
   it('throws an error if schema version cannot be found', () => {
     expect(() => {
       migrateProtocol({
-        schemaVersion: '-999',
+        schemaVersion: '-555',
       }, '2');
-    }).toThrow(errors.CurrentProtocolNotFoundError);
+    }).toThrow(/Protocol version "-555" not found./);
   });
 
   it('throws an error if target version cannot be found', () => {
     expect(() => {
       migrateProtocol(mockProtocol, '-999');
-    }).toThrow(errors.TargetProtocolNotFoundError);
+    }).toThrow(/Protocol version "-999" not found./);
+  });
+
+  it('throws an error if we try to migrate downwards', () => {
+    expect(() => {
+      migrateProtocol({
+        schemaVersion: '3',
+      }, '1');
+    }).toThrow(/Migration to this version is not possible from "3" to "1"./);
   });
 
   it('throws an error migration run on a blocking migration path', () => {
     expect(() => {
       migrateProtocol(mockProtocol, '4');
-    }).toThrow(errors.MigrationNotPossibleError);
+    }).toThrow(/Migration to this version is not possible from "1" to "4"./);
   });
 
   it('throws a generic MigrationError error migration step throws an error', () => {

--- a/migrations/canUpgrade.js
+++ b/migrations/canUpgrade.js
@@ -1,0 +1,13 @@
+const getMigrationPath = require('./getMigrationPath');
+
+const canUpgrade = (protocol, targetSchemaVersion) => {
+  try {
+    getMigrationPath(protocol, targetSchemaVersion);
+  } catch (e) {
+    return false;
+  }
+
+  return true;
+};
+
+module.exports = canUpgrade;

--- a/migrations/errors.js
+++ b/migrations/errors.js
@@ -1,9 +1,44 @@
-const CurrentProtocolNotFoundError = new Error('Current protocol version not found');
-const TargetProtocolNotFoundError = new Error('Target protocol version not found');
-const MigrationNotPossibleError = new Error('Migration to this version is not possible');
+class VersionNotFoundError extends Error {
+  constructor(version = undefined, ...params) {
+    super(...params);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, VersionNotFoundError);
+    }
+
+    this.name = 'VersionNotFoundError';
+    this.message = `Protocol version ${JSON.stringify(version)} not found.`;
+  }
+}
+
+class MigrationNotPossibleError extends Error {
+  constructor(from = undefined, to = undefined, ...params) {
+    super(...params);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MigrationNotPossibleError);
+    }
+
+    this.name = 'MigrationNotPossibleError';
+    this.message = `Migration to this version is not possible from ${JSON.stringify(from)} to ${JSON.stringify(to)}.`;
+  }
+}
+
+class VersionOutmatchError extends Error {
+  constructor(from = undefined, to = undefined, ...params) {
+    super(...params);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, VersionOutmatchError);
+    }
+
+    this.name = 'MigrationNotPossibleError';
+    this.message = `Source version (${JSON.stringify(from)}) outmatches target version(${JSON.stringify(to)}).`;
+  }
+}
 
 module.exports = {
-  CurrentProtocolNotFoundError,
-  TargetProtocolNotFoundError,
+  VersionNotFoundError,
+  VersionOutmatchError,
   MigrationNotPossibleError,
 };

--- a/migrations/getMigrationIndex.js
+++ b/migrations/getMigrationIndex.js
@@ -1,0 +1,17 @@
+const migrations = require('./migrations');
+
+const matchVersion = targetVersion =>
+  ({ version }) =>
+    version === targetVersion;
+
+const getMigrationIndex = (version) => {
+  const migrationIndex = migrations.findIndex(matchVersion(version));
+
+  if (migrationIndex === -1) {
+    return null;
+  }
+
+  return migrationIndex;
+};
+
+module.exports = getMigrationIndex;

--- a/migrations/migrateProtocol.js
+++ b/migrations/migrateProtocol.js
@@ -11,7 +11,7 @@ const migrateStep = (protocol, { version, migration }) => {
 
 const migrateProtocol = (protocol, targetSchemaVersion) => {
   // Get migration steps between versions
-  const migrationPath = getMigrationPath(protocol, targetSchemaVersion);
+  const migrationPath = getMigrationPath(protocol.schemaVersion, targetSchemaVersion);
 
   // Perform migration
   const updatedProtocol = migrationPath.reduce(migrateStep, protocol);


### PR DESCRIPTION
Because protocol versions are non-numeric, with order being defined in the migrations file, version comparison needs to be defered to the migrations tools, and not determined by a direct comparison (e.g. `schemaVersion > appSchemaVersion`)

Additionally improves error messages.

Required by: https://github.com/codaco/Architect/pull/567