### PR TITLE
Add shim to migrate old version 1.0.0

### DIFF
--- a/migrations/__tests__/__snapshots__/stringVersion.test.js.snap
+++ b/migrations/__tests__/__snapshots__/stringVersion.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`string version handling migrates version "1.0.0" correctly 1`] = `
+Object {
+  "codebook": Object {
+    "node": Object {
+      "disallowedType": Object {
+        "name": "disallowed_type_name",
+        "variables": Object {
+          "invalidExampleVariable": Object {
+            "name": "variable_with_disallowed_characters",
+          },
+          "invalidExampleVariableDuplicate": Object {
+            "name": "variable_with_disallowed_characters2",
+          },
+        },
+      },
+    },
+  },
+  "schemaVersion": 4,
+}
+`;

--- a/migrations/__tests__/getMigrationPath.test.js
+++ b/migrations/__tests__/getMigrationPath.test.js
@@ -1,0 +1,50 @@
+/* eslint-env jest */
+
+const getMigrationPath = require('../getMigrationPath');
+
+/**
+ * Migrations are run in the order that they are defined relative to one another
+ * e.g. 1 -> 3, will run 1 -> 2 -> 3
+ */
+
+// const
+
+// const isMigrationPathValid = path =>
+//   !path.some(({ migration }) => !migration);
+
+// const matchMigrations = (sourceVersion, targetVersion) =>
+//   ({ version }) =>
+//     version > sourceVersion && version <= targetVersion;
+
+// const getMigrationPath = (sourceSchemaVersion, targetSchemaVersion) => {
+//   if (sourceSchemaVersion >= targetSchemaVersion) {
+//     throw new VersionMismatchError(sourceSchemaVersion, targetSchemaVersion);
+//   }
+
+//   // Get migration steps between versions
+//   const migrationPath = migrations.filter(
+//     matchMigrations(sourceSchemaVersion, targetSchemaVersion),
+//   );
+
+//   if (!isMigrationPathValid(migrationPath)) {
+//     throw new MigrationNotPossibleError(sourceSchemaVersion, targetSchemaVersion);
+//   }
+
+//   return migrationPath;
+// };
+
+describe('migrateProtocol', () => {
+  it('gets the correct migration path for a protocol', () => {
+    const migrationPath = getMigrationPath(1, 4);
+
+    expect(migrationPath.length).toBe(3);
+
+    expect(migrationPath).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ version: 2 }),
+        expect.objectContaining({ version: 3 }),
+        expect.objectContaining({ version: 4 }),
+      ]),
+    );
+  });
+});

--- a/migrations/__tests__/migrateProtocol.test.js
+++ b/migrations/__tests__/migrateProtocol.test.js
@@ -37,17 +37,17 @@ describe('migrateProtocol', () => {
   });
 
   it('migrations transform protocol successively', () => {
-    const resultProtocol = migrateProtocol(mockProtocol, 3);
+    const [resultProtocol] = migrateProtocol(mockProtocol, 3);
 
     expect(resultProtocol).toEqual({ bazz: 'buzz', fizz: 'pop', schemaVersion: 3 });
   });
 
   it('will migrate when there are no steps', () => {
-    expect(
-      migrateProtocol({
-        schemaVersion: 99,
-      }, 999),
-    ).toEqual({
+    const [newProtocol] = migrateProtocol({
+      schemaVersion: 99,
+    }, 999);
+
+    expect(newProtocol).toEqual({
       schemaVersion: 999,
     });
   });

--- a/migrations/__tests__/stringVersion.test.js
+++ b/migrations/__tests__/stringVersion.test.js
@@ -24,7 +24,7 @@ const v1Protocol = {
 
 describe('string version handling', () => {
   it('migrates version "1.0.0" correctly', () => {
-    const result = migrateProtocol(v1Protocol, 4);
+    const [result] = migrateProtocol(v1Protocol, 4);
 
     expect(result).toMatchSnapshot();
   });
@@ -35,12 +35,12 @@ describe('string version handling', () => {
         ...v1Protocol,
         schemaVersion: '2.0.0',
       }, 4);
-    }).toThrow('Source protocol schemaVersion "2.0.0" not recognised. Is a string.');
+    }).toThrow('The source schema version is not recognised, must be an integer ("2.0.0").');
   });
 
   it('throws an error for target string version numbers', () => {
     expect(() => {
       migrateProtocol(v1Protocol, '4.0.0');
-    }).toThrow('Target schemaVersion "4.0.0" must be an integer.');
+    }).toThrow('The target schema version is not recognised, must be an integer ("4.0.0").');
   });
 });

--- a/migrations/__tests__/stringVersion.test.js
+++ b/migrations/__tests__/stringVersion.test.js
@@ -1,0 +1,46 @@
+/* eslint-env jest */
+
+const migrateProtocol = require('../migrateProtocol');
+
+const v1Protocol = {
+  schemaVersion: '1.0.0',
+  codebook: {
+    node: {
+      disallowedType: {
+        name: 'disallowed type name',
+        variables: {
+          invalidExampleVariable: {
+            name: 'variable (with) disallowed characters!',
+          },
+          invalidExampleVariableDuplicate: {
+            // should resolve to the same as previous, therefore needs incrementing
+            name: 'variable (with) disallowed characters?',
+          },
+        },
+      },
+    },
+  },
+};
+
+describe('string version handling', () => {
+  it('migrates version "1.0.0" correctly', () => {
+    const result = migrateProtocol(v1Protocol, 4);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('throws an error for other source string version numbers', () => {
+    expect(() => {
+      migrateProtocol({
+        ...v1Protocol,
+        schemaVersion: '2.0.0',
+      }, 4);
+    }).toThrow('Source protocol schemaVersion "2.0.0" not recognised. Is a string.');
+  });
+
+  it('throws an error for target string version numbers', () => {
+    expect(() => {
+      migrateProtocol(v1Protocol, '4.0.0');
+    }).toThrow('Target schemaVersion "4.0.0" must be an integer.');
+  });
+});

--- a/migrations/errors.js
+++ b/migrations/errors.js
@@ -37,8 +37,22 @@ class MigrationStepError extends Error {
   }
 }
 
+class StringVersionError extends Error {
+  constructor(version = undefined, type = undefined, ...params) {
+    super(...params);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MigrationNotPossibleError);
+    }
+
+    this.name = 'StringVersionError';
+    this.message = `The ${type} schema version is not recognised, must be an integer (${JSON.stringify(version)}).`;
+  }
+}
+
 module.exports = {
   VersionMismatchError,
   MigrationNotPossibleError,
   MigrationStepError,
+  StringVersionError,
 };

--- a/migrations/getMigrationPath.js
+++ b/migrations/getMigrationPath.js
@@ -9,7 +9,19 @@ const matchMigrations = (sourceVersion, targetVersion) =>
   ({ version }) =>
     version > sourceVersion && version <= targetVersion;
 
-const getMigrationPath = (sourceSchemaVersion, targetSchemaVersion) => {
+const getMigrationPath = (rawSourceSchemaVersion, targetSchemaVersion) => {
+  if (!Number.isInteger(targetSchemaVersion)) {
+    throw new Error(`Target schemaVersion ${JSON.stringify(targetSchemaVersion)} must be an integer.`);
+  }
+
+  // This is a shim for the original schema which used the format "1.0.0"
+  const sourceSchemaVersion = rawSourceSchemaVersion === '1.0.0' ? 1 : rawSourceSchemaVersion;
+
+  // In case string version numbers are accidentally reintroduced.
+  if (!Number.isInteger(sourceSchemaVersion)) {
+    throw new Error(`Source protocol schemaVersion ${JSON.stringify(sourceSchemaVersion)} not recognised. Is a string.`);
+  }
+
   if (sourceSchemaVersion >= targetSchemaVersion) {
     throw new VersionMismatchError(sourceSchemaVersion, targetSchemaVersion);
   }

--- a/migrations/getMigrationPath.js
+++ b/migrations/getMigrationPath.js
@@ -1,6 +1,7 @@
 const migrations = require('./migrations');
 const MigrationNotPossibleError = require('./errors').MigrationNotPossibleError;
 const VersionMismatchError = require('./errors').VersionMismatchError;
+const StringVersionError = require('./errors').StringVersionError;
 
 const isMigrationPathValid = path =>
   !path.some(({ migration }) => !migration);
@@ -11,7 +12,7 @@ const matchMigrations = (sourceVersion, targetVersion) =>
 
 const getMigrationPath = (rawSourceSchemaVersion, targetSchemaVersion) => {
   if (!Number.isInteger(targetSchemaVersion)) {
-    throw new Error(`Target schemaVersion ${JSON.stringify(targetSchemaVersion)} must be an integer.`);
+    throw new StringVersionError(targetSchemaVersion, 'target');
   }
 
   // This is a shim for the original schema which used the format "1.0.0"
@@ -19,7 +20,7 @@ const getMigrationPath = (rawSourceSchemaVersion, targetSchemaVersion) => {
 
   // In case string version numbers are accidentally reintroduced.
   if (!Number.isInteger(sourceSchemaVersion)) {
-    throw new Error(`Source protocol schemaVersion ${JSON.stringify(sourceSchemaVersion)} not recognised. Is a string.`);
+    throw new StringVersionError(sourceSchemaVersion, 'source');
   }
 
   if (sourceSchemaVersion >= targetSchemaVersion) {

--- a/migrations/migrateProtocol.js
+++ b/migrations/migrateProtocol.js
@@ -16,10 +16,26 @@ const migrateProtocol = (protocol, targetSchemaVersion) => {
   // Perform migration
   const updatedProtocol = migrationPath.reduce(migrateStep, protocol);
 
-  return {
+  const resultProtocol = {
     ...updatedProtocol,
     schemaVersion: targetSchemaVersion,
   };
+
+  const { migrations } = migrationPath
+    .reduce(
+      (acc, { version }) => {
+        return {
+          previous: version,
+          migrations: [...acc.migrations, [acc.previous, version]],
+        };
+      },
+      { previous: protocol.schemaVersion, migrations: [] },
+    );
+
+  return [
+    resultProtocol,
+    migrations,
+  ];
 };
 
 module.exports = migrateProtocol;

--- a/migrations/migrations/4.js
+++ b/migrations/migrations/4.js
@@ -67,10 +67,14 @@ const migration = (protocol) => {
     ego: migrateType(codebook.ego),
   }, codebook);
 
-  return {
+  const newProtocol = {
     ...protocol,
     codebook: newCodebook,
   };
+
+  console.log(JSON.stringify(newProtocol, null, 2));
+
+  return newProtocol;
 };
 
 // Markdown format

--- a/migrations/migrations/4.js
+++ b/migrations/migrations/4.js
@@ -67,14 +67,10 @@ const migration = (protocol) => {
     ego: migrateType(codebook.ego),
   }, codebook);
 
-  const newProtocol = {
+  return {
     ...protocol,
     codebook: newCodebook,
   };
-
-  console.log(JSON.stringify(newProtocol, null, 2));
-
-  return newProtocol;
 };
 
 // Markdown format

--- a/migrations/migrations/__tests__/4.test.js
+++ b/migrations/migrations/__tests__/4.test.js
@@ -2,7 +2,7 @@
 
 const version4 = require('../4');
 
-const v4protocol = {
+const v3Protocol = {
   codebook: {
     node: {
       disallowedType: {
@@ -52,13 +52,13 @@ const v4protocol = {
 
 describe('migrate v3 -> v4', () => {
   it('migrates codebook', () => {
-    const result = version4.migration(v4protocol);
+    const result = version4.migration(v3Protocol);
 
     expect(result).toMatchSnapshot();
   });
 
   it('type names', () => {
-    const result = version4.migration(v4protocol);
+    const result = version4.migration(v3Protocol);
 
     const nodeDefinitions = result.codebook.node;
 
@@ -69,7 +69,7 @@ describe('migrate v3 -> v4', () => {
   });
 
   it('variable names', () => {
-    const result = version4.migration(v4protocol);
+    const result = version4.migration(v3Protocol);
 
     const variables = result.codebook.node.disallowedType.variables;
     expect(variables.invalidExampleVariable.name).toBe('variable_with_disallowed_characters');
@@ -79,7 +79,7 @@ describe('migrate v3 -> v4', () => {
   });
 
   it('option values', () => {
-    const result = version4.migration(v4protocol);
+    const result = version4.migration(v3Protocol);
 
     const options = result.codebook.node.disallowedType.variables.invalidExampleVariable.options;
     expect(options).toEqual(expect.arrayContaining([

--- a/migrations/migrations/index.js
+++ b/migrations/migrations/index.js
@@ -1,5 +1,8 @@
 const version4 = require('./4');
 
+/**
+ * These should be in order
+ */
 const migrations = [
   { version: 1, migration: protocol => protocol },
   { version: 2, migration: protocol => protocol },

--- a/migrations/migrations/index.js
+++ b/migrations/migrations/index.js
@@ -4,6 +4,7 @@ const version4 = require('./4');
  * These should be in order
  */
 const migrations = [
+  { version: '1.0.0', migration: protocol => protocol },
   { version: 1, migration: protocol => protocol },
   { version: 2, migration: protocol => protocol },
   { version: 3, migration: protocol => protocol },


### PR DESCRIPTION
This helps to resolve https://github.com/complexdatacollective/Architect/issues/665 by adding an exception to resolve the old string schema version "1.0.0".

It also adds errors for non-integer schema versions (except for "1.0.0").

The return format from migrateProtocol() has been changed to include migration information as an array in the format:
```js
const [updatedProtocol, migrationSteps] = migrateProtocol(protocol, targetVersion);

// migrationSteps
[
  [from, to],
  ...,
]
```