### PR TITLE
Feature/two mode sociogram

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "protocol-validation",
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "eslint-plugin-jsx-a11y": "5.1.1",
     "eslint-plugin-react": "^7.11.1",
     "fs-extra": "^8.0.1",
-    "jszip": "^3.2.1"
+    "jszip": "^3.2.1",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "jest": "^24.8.0",
-    "lodash": "^4.17.21"
+    "jest": "^24.8.0"
   }
 }

--- a/schemas/8.js
+++ b/schemas/8.js
@@ -5873,7 +5873,7 @@ var validate = (function() {
         var errs__0 = errors;
         var valid1 = true;
         for (var key0 in data) {
-          var isAdditional0 = !(false || key0 == 'property' || key0 == 'direction');
+          var isAdditional0 = !(false || key0 == 'property' || key0 == 'direction' || key0 == 'type' || key0 == 'hierarchy');
           if (isAdditional0) {
             valid1 = false;
             var err = {
@@ -5890,8 +5890,7 @@ var validate = (function() {
             errors++;
           }
         }
-        var data1 = data.property;
-        if (data1 === undefined) {
+        if (data.property === undefined) {
           valid1 = false;
           var err = {
             keyword: 'required',
@@ -5907,14 +5906,11 @@ var validate = (function() {
           errors++;
         } else {
           var errs_1 = errors;
-          var errs__1 = errors;
-          var valid1 = false;
-          var errs_2 = errors;
-          if (typeof data1 !== "string") {
+          if (typeof data.property !== "string") {
             var err = {
               keyword: 'type',
               dataPath: (dataPath || '') + '.property',
-              schemaPath: '#/properties/property/anyOf/0/type',
+              schemaPath: '#/properties/property/type',
               params: {
                 type: 'string'
               },
@@ -5924,63 +5920,10 @@ var validate = (function() {
             else vErrors.push(err);
             errors++;
           }
-          var valid2 = errors === errs_2;
-          valid1 = valid1 || valid2;
-          if (!valid1) {
-            var errs_2 = errors;
-            if ((!data1 || typeof data1 !== "object" || Array.isArray(data1))) {
-              var err = {
-                keyword: 'type',
-                dataPath: (dataPath || '') + '.property',
-                schemaPath: '#/properties/property/anyOf/1/type',
-                params: {
-                  type: 'object'
-                },
-                message: 'should be object'
-              };
-              if (vErrors === null) vErrors = [err];
-              else vErrors.push(err);
-              errors++;
-            }
-            var valid2 = errors === errs_2;
-            valid1 = valid1 || valid2;
-          }
-          if (!valid1) {
-            var err = {
-              keyword: 'anyOf',
-              dataPath: (dataPath || '') + '.property',
-              schemaPath: '#/properties/property/anyOf',
-              params: {},
-              message: 'should match some schema in anyOf'
-            };
-            if (vErrors === null) vErrors = [err];
-            else vErrors.push(err);
-            errors++;
-          } else {
-            errors = errs__1;
-            if (vErrors !== null) {
-              if (errs__1) vErrors.length = errs__1;
-              else vErrors = null;
-            }
-          }
           var valid1 = errors === errs_1;
         }
         var data1 = data.direction;
-        if (data1 === undefined) {
-          valid1 = false;
-          var err = {
-            keyword: 'required',
-            dataPath: (dataPath || '') + "",
-            schemaPath: '#/required',
-            params: {
-              missingProperty: 'direction'
-            },
-            message: 'should have required property \'direction\''
-          };
-          if (vErrors === null) vErrors = [err];
-          else vErrors.push(err);
-          errors++;
-        } else {
+        if (data1 !== undefined) {
           var errs_1 = errors;
           var errs_2 = errors;
           if (typeof data1 !== "string") {
@@ -6021,6 +5964,72 @@ var validate = (function() {
           var valid2 = errors === errs_2;
           var valid1 = errors === errs_1;
         }
+        if (data.type !== undefined) {
+          var errs_1 = errors;
+          var schema1 = validate.schema.properties.type.enum;
+          var valid1;
+          valid1 = false;
+          for (var i1 = 0; i1 < schema1.length; i1++)
+            if (equal(data.type, schema1[i1])) {
+              valid1 = true;
+              break;
+            } if (!valid1) {
+            var err = {
+              keyword: 'enum',
+              dataPath: (dataPath || '') + '.type',
+              schemaPath: '#/properties/type/enum',
+              params: {
+                allowedValues: schema1
+              },
+              message: 'should be equal to one of the allowed values'
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
+          }
+          var valid1 = errors === errs_1;
+        }
+        var data1 = data.hierarchy;
+        if (data1 !== undefined) {
+          var errs_1 = errors;
+          if (Array.isArray(data1)) {
+            var errs__1 = errors;
+            var valid1;
+            for (var i1 = 0; i1 < data1.length; i1++) {
+              var data2 = data1[i1];
+              var errs_2 = errors;
+              if (typeof data2 !== "string" && typeof data2 !== "number" && typeof data2 !== "boolean") {
+                var err = {
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.hierarchy[' + i1 + ']',
+                  schemaPath: '#/properties/hierarchy/items/type',
+                  params: {
+                    type: 'string,number,boolean'
+                  },
+                  message: 'should be string,number,boolean'
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+          } else {
+            var err = {
+              keyword: 'type',
+              dataPath: (dataPath || '') + '.hierarchy',
+              schemaPath: '#/properties/hierarchy/type',
+              params: {
+                type: 'array'
+              },
+              message: 'should be array'
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
+          }
+          var valid1 = errors === errs_1;
+        }
       } else {
         var err = {
           keyword: 'type',
@@ -6044,17 +6053,22 @@ var validate = (function() {
     "additionalProperties": false,
     "properties": {
       "property": {
-        "anyOf": [{
-          "type": "string"
-        }, {
-          "type": "object"
-        }]
+        "type": "string"
       },
       "direction": {
         "$ref": "#/definitions/Direction"
+      },
+      "type": {
+        "enum": ["string", "number", "boolean", "date", "hierarchy"]
+      },
+      "hierarchy": {
+        "type": "array",
+        "items": {
+          "type": ["string", "number", "boolean"]
+        }
       }
     },
-    "required": ["direction", "property"],
+    "required": ["property"],
     "title": "SortOrder"
   };
   refVal27.errors = null;
@@ -8108,17 +8122,22 @@ validate.schema = {
       "additionalProperties": false,
       "properties": {
         "property": {
-          "anyOf": [{
-            "type": "string"
-          }, {
-            "type": "object"
-          }]
+          "type": "string"
         },
         "direction": {
           "$ref": "#/definitions/Direction"
+        },
+        "type": {
+          "enum": ["string", "number", "boolean", "date", "hierarchy"]
+        },
+        "hierarchy": {
+          "type": "array",
+          "items": {
+            "type": ["string", "number", "boolean"]
+          }
         }
       },
-      "required": ["direction", "property"],
+      "required": ["property"],
       "title": "SortOrder"
     },
     "CardOptions": {

--- a/schemas/8.js
+++ b/schemas/8.js
@@ -2122,6 +2122,34 @@ var validate = (function() {
           if (!valid1) {
             var errs_2 = errors;
             if (Array.isArray(data1)) {
+              if (data1.length > 2) {
+                var err = {
+                  keyword: 'maxItems',
+                  dataPath: (dataPath || '') + '.subject',
+                  schemaPath: '#/properties/subject/anyOf/1/maxItems',
+                  params: {
+                    limit: 2
+                  },
+                  message: 'should NOT have more than 2 items'
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              if (data1.length < 1) {
+                var err = {
+                  keyword: 'minItems',
+                  dataPath: (dataPath || '') + '.subject',
+                  schemaPath: '#/properties/subject/anyOf/1/minItems',
+                  params: {
+                    limit: 1
+                  },
+                  message: 'should NOT have fewer than 1 items'
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
               var errs__2 = errors;
               var valid2;
               for (var i2 = 0; i2 < data1.length; i2++) {
@@ -3571,6 +3599,8 @@ var validate = (function() {
           "$ref": "#/definitions/Subject"
         }, {
           "type": "array",
+          "minItems": 1,
+          "maxItems": 2,
           "items": {
             "$ref": "#/definitions/Subject"
           }
@@ -7632,6 +7662,8 @@ validate.schema = {
             "$ref": "#/definitions/Subject"
           }, {
             "type": "array",
+            "minItems": 1,
+            "maxItems": 2,
             "items": {
               "$ref": "#/definitions/Subject"
             }

--- a/schemas/8.js
+++ b/schemas/8.js
@@ -2106,12 +2106,67 @@ var validate = (function() {
           }
           var valid1 = errors === errs_1;
         }
-        if (data.subject !== undefined) {
+        var data1 = data.subject;
+        if (data1 !== undefined) {
           var errs_1 = errors;
-          if (!refVal18(data.subject, (dataPath || '') + '.subject', data, 'subject', rootData)) {
+          var errs__1 = errors;
+          var valid1 = false;
+          var errs_2 = errors;
+          if (!refVal18(data1, (dataPath || '') + '.subject', data, 'subject', rootData)) {
             if (vErrors === null) vErrors = refVal18.errors;
             else vErrors = vErrors.concat(refVal18.errors);
             errors = vErrors.length;
+          }
+          var valid2 = errors === errs_2;
+          valid1 = valid1 || valid2;
+          if (!valid1) {
+            var errs_2 = errors;
+            if (Array.isArray(data1)) {
+              var errs__2 = errors;
+              var valid2;
+              for (var i2 = 0; i2 < data1.length; i2++) {
+                var errs_3 = errors;
+                if (!refVal[18](data1[i2], (dataPath || '') + '.subject[' + i2 + ']', data1, i2, rootData)) {
+                  if (vErrors === null) vErrors = refVal[18].errors;
+                  else vErrors = vErrors.concat(refVal[18].errors);
+                  errors = vErrors.length;
+                }
+                var valid3 = errors === errs_3;
+              }
+            } else {
+              var err = {
+                keyword: 'type',
+                dataPath: (dataPath || '') + '.subject',
+                schemaPath: '#/properties/subject/anyOf/1/type',
+                params: {
+                  type: 'array'
+                },
+                message: 'should be array'
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            }
+            var valid2 = errors === errs_2;
+            valid1 = valid1 || valid2;
+          }
+          if (!valid1) {
+            var err = {
+              keyword: 'anyOf',
+              dataPath: (dataPath || '') + '.subject',
+              schemaPath: '#/properties/subject/anyOf',
+              params: {},
+              message: 'should match some schema in anyOf'
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
+          } else {
+            errors = errs__1;
+            if (vErrors !== null) {
+              if (errs__1) vErrors.length = errs__1;
+              else vErrors = null;
+            }
           }
           var valid1 = errors === errs_1;
         }
@@ -3512,7 +3567,14 @@ var validate = (function() {
         "type": ["string", "null"]
       },
       "subject": {
-        "$ref": "#/definitions/Subject"
+        "anyOf": [{
+          "$ref": "#/definitions/Subject"
+        }, {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Subject"
+          }
+        }]
       },
       "panels": {
         "type": "array",
@@ -5124,7 +5186,8 @@ var validate = (function() {
                 errors++;
               }
             }
-            if (data1.layoutVariable === undefined) {
+            var data2 = data1.layoutVariable;
+            if (data2 === undefined) {
               valid3 = false;
               var err = {
                 keyword: 'required',
@@ -5140,11 +5203,14 @@ var validate = (function() {
               errors++;
             } else {
               var errs_3 = errors;
-              if (typeof data1.layoutVariable !== "string") {
+              var errs__3 = errors;
+              var valid3 = false;
+              var errs_4 = errors;
+              if (typeof data2 !== "string") {
                 var err = {
                   keyword: 'type',
                   dataPath: (dataPath || '') + '.layout.layoutVariable',
-                  schemaPath: '#/definitions/Layout/properties/layoutVariable/type',
+                  schemaPath: '#/definitions/Layout/properties/layoutVariable/anyOf/0/type',
                   params: {
                     type: 'string'
                   },
@@ -5153,6 +5219,45 @@ var validate = (function() {
                 if (vErrors === null) vErrors = [err];
                 else vErrors.push(err);
                 errors++;
+              }
+              var valid4 = errors === errs_4;
+              valid3 = valid3 || valid4;
+              if (!valid3) {
+                var errs_4 = errors;
+                if ((!data2 || typeof data2 !== "object" || Array.isArray(data2))) {
+                  var err = {
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.layout.layoutVariable',
+                    schemaPath: '#/definitions/Layout/properties/layoutVariable/anyOf/1/type',
+                    params: {
+                      type: 'object'
+                    },
+                    message: 'should be object'
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid4 = errors === errs_4;
+                valid3 = valid3 || valid4;
+              }
+              if (!valid3) {
+                var err = {
+                  keyword: 'anyOf',
+                  dataPath: (dataPath || '') + '.layout.layoutVariable',
+                  schemaPath: '#/definitions/Layout/properties/layoutVariable/anyOf',
+                  params: {},
+                  message: 'should match some schema in anyOf'
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                errors = errs__3;
+                if (vErrors !== null) {
+                  if (errs__3) vErrors.length = errs__3;
+                  else vErrors = null;
+                }
               }
               var valid3 = errors === errs_3;
             }
@@ -5199,7 +5304,7 @@ var validate = (function() {
             var errs__2 = errors;
             var valid3 = true;
             for (var key2 in data1) {
-              var isAdditional2 = !(false || key2 == 'display' || key2 == 'create');
+              var isAdditional2 = !(false || key2 == 'display' || key2 == 'create' || key2 == 'restrict');
               if (isAdditional2) {
                 valid3 = false;
                 var err = {
@@ -5267,6 +5372,86 @@ var validate = (function() {
                     type: 'string'
                   },
                   message: 'should be string'
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid3 = errors === errs_3;
+            }
+            var data2 = data1.restrict;
+            if (data2 !== undefined) {
+              var errs_3 = errors;
+              if ((data2 && typeof data2 === "object" && !Array.isArray(data2))) {
+                var errs__3 = errors;
+                var valid4 = true;
+                if (data2.origin !== undefined) {
+                  var errs_4 = errors;
+                  if (typeof data2.origin !== "string") {
+                    var err = {
+                      keyword: 'type',
+                      dataPath: (dataPath || '') + '.edges.restrict.origin',
+                      schemaPath: '#/definitions/Edges/properties/restrict/properties/origin/type',
+                      params: {
+                        type: 'string'
+                      },
+                      message: 'should be string'
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid4 = errors === errs_4;
+                }
+                var data3 = data2.destination;
+                if (data3 !== undefined) {
+                  var errs_4 = errors;
+                  if (typeof data3 !== "string") {
+                    var err = {
+                      keyword: 'type',
+                      dataPath: (dataPath || '') + '.edges.restrict.destination',
+                      schemaPath: '#/definitions/Edges/properties/restrict/properties/destination/type',
+                      params: {
+                        type: 'string'
+                      },
+                      message: 'should be string'
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var schema4 = refVal30.properties.restrict.properties.destination.enum;
+                  var valid4;
+                  valid4 = false;
+                  for (var i4 = 0; i4 < schema4.length; i4++)
+                    if (equal(data3, schema4[i4])) {
+                      valid4 = true;
+                      break;
+                    } if (!valid4) {
+                    var err = {
+                      keyword: 'enum',
+                      dataPath: (dataPath || '') + '.edges.restrict.destination',
+                      schemaPath: '#/definitions/Edges/properties/restrict/properties/destination/enum',
+                      params: {
+                        allowedValues: schema4
+                      },
+                      message: 'should be equal to one of the allowed values'
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid4 = errors === errs_4;
+                }
+              } else {
+                var err = {
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.edges.restrict',
+                  schemaPath: '#/definitions/Edges/properties/restrict/type',
+                  params: {
+                    type: 'object'
+                  },
+                  message: 'should be object'
                 };
                 if (vErrors === null) vErrors = [err];
                 else vErrors.push(err);
@@ -5675,7 +5860,8 @@ var validate = (function() {
             errors++;
           }
         }
-        if (data.property === undefined) {
+        var data1 = data.property;
+        if (data1 === undefined) {
           valid1 = false;
           var err = {
             keyword: 'required',
@@ -5691,11 +5877,14 @@ var validate = (function() {
           errors++;
         } else {
           var errs_1 = errors;
-          if (typeof data.property !== "string") {
+          var errs__1 = errors;
+          var valid1 = false;
+          var errs_2 = errors;
+          if (typeof data1 !== "string") {
             var err = {
               keyword: 'type',
               dataPath: (dataPath || '') + '.property',
-              schemaPath: '#/properties/property/type',
+              schemaPath: '#/properties/property/anyOf/0/type',
               params: {
                 type: 'string'
               },
@@ -5704,6 +5893,45 @@ var validate = (function() {
             if (vErrors === null) vErrors = [err];
             else vErrors.push(err);
             errors++;
+          }
+          var valid2 = errors === errs_2;
+          valid1 = valid1 || valid2;
+          if (!valid1) {
+            var errs_2 = errors;
+            if ((!data1 || typeof data1 !== "object" || Array.isArray(data1))) {
+              var err = {
+                keyword: 'type',
+                dataPath: (dataPath || '') + '.property',
+                schemaPath: '#/properties/property/anyOf/1/type',
+                params: {
+                  type: 'object'
+                },
+                message: 'should be object'
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            }
+            var valid2 = errors === errs_2;
+            valid1 = valid1 || valid2;
+          }
+          if (!valid1) {
+            var err = {
+              keyword: 'anyOf',
+              dataPath: (dataPath || '') + '.property',
+              schemaPath: '#/properties/property/anyOf',
+              params: {},
+              message: 'should match some schema in anyOf'
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
+          } else {
+            errors = errs__1;
+            if (vErrors !== null) {
+              if (errs__1) vErrors.length = errs__1;
+              else vErrors = null;
+            }
           }
           var valid1 = errors === errs_1;
         }
@@ -5786,7 +6014,11 @@ var validate = (function() {
     "additionalProperties": false,
     "properties": {
       "property": {
-        "type": "string"
+        "anyOf": [{
+          "type": "string"
+        }, {
+          "type": "object"
+        }]
       },
       "direction": {
         "$ref": "#/definitions/Direction"
@@ -5808,7 +6040,11 @@ var validate = (function() {
     "additionalProperties": false,
     "properties": {
       "layoutVariable": {
-        "type": "string"
+        "anyOf": [{
+          "type": "string"
+        }, {
+          "type": "object"
+        }]
       },
       "allowPositioning": {
         "type": "boolean"
@@ -5830,6 +6066,18 @@ var validate = (function() {
       },
       "create": {
         "type": "string"
+      },
+      "restrict": {
+        "type": "object",
+        "properties": {
+          "origin": {
+            "type": "string"
+          },
+          "destination": {
+            "type": "string",
+            "enum": ["same", "different", "all"]
+          }
+        }
       }
     },
     "required": [],
@@ -6001,7 +6249,7 @@ var validate = (function() {
             var errs__2 = errors;
             var valid3 = true;
             for (var key2 in data1) {
-              var isAdditional2 = !(false || key2 == 'display' || key2 == 'create');
+              var isAdditional2 = !(false || key2 == 'display' || key2 == 'create' || key2 == 'restrict');
               if (isAdditional2) {
                 valid3 = false;
                 var err = {
@@ -6069,6 +6317,86 @@ var validate = (function() {
                     type: 'string'
                   },
                   message: 'should be string'
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid3 = errors === errs_3;
+            }
+            var data2 = data1.restrict;
+            if (data2 !== undefined) {
+              var errs_3 = errors;
+              if ((data2 && typeof data2 === "object" && !Array.isArray(data2))) {
+                var errs__3 = errors;
+                var valid4 = true;
+                if (data2.origin !== undefined) {
+                  var errs_4 = errors;
+                  if (typeof data2.origin !== "string") {
+                    var err = {
+                      keyword: 'type',
+                      dataPath: (dataPath || '') + '.edges.restrict.origin',
+                      schemaPath: '#/definitions/Edges/properties/restrict/properties/origin/type',
+                      params: {
+                        type: 'string'
+                      },
+                      message: 'should be string'
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid4 = errors === errs_4;
+                }
+                var data3 = data2.destination;
+                if (data3 !== undefined) {
+                  var errs_4 = errors;
+                  if (typeof data3 !== "string") {
+                    var err = {
+                      keyword: 'type',
+                      dataPath: (dataPath || '') + '.edges.restrict.destination',
+                      schemaPath: '#/definitions/Edges/properties/restrict/properties/destination/type',
+                      params: {
+                        type: 'string'
+                      },
+                      message: 'should be string'
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var schema4 = refVal[30].properties.restrict.properties.destination.enum;
+                  var valid4;
+                  valid4 = false;
+                  for (var i4 = 0; i4 < schema4.length; i4++)
+                    if (equal(data3, schema4[i4])) {
+                      valid4 = true;
+                      break;
+                    } if (!valid4) {
+                    var err = {
+                      keyword: 'enum',
+                      dataPath: (dataPath || '') + '.edges.restrict.destination',
+                      schemaPath: '#/definitions/Edges/properties/restrict/properties/destination/enum',
+                      params: {
+                        allowedValues: schema4
+                      },
+                      message: 'should be equal to one of the allowed values'
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid4 = errors === errs_4;
+                }
+              } else {
+                var err = {
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.edges.restrict',
+                  schemaPath: '#/definitions/Edges/properties/restrict/type',
+                  params: {
+                    type: 'object'
+                  },
+                  message: 'should be object'
                 };
                 if (vErrors === null) vErrors = [err];
                 else vErrors.push(err);
@@ -7300,7 +7628,14 @@ validate.schema = {
           "type": ["string", "null"]
         },
         "subject": {
-          "$ref": "#/definitions/Subject"
+          "anyOf": [{
+            "$ref": "#/definitions/Subject"
+          }, {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Subject"
+            }
+          }]
         },
         "panels": {
           "type": "array",
@@ -7741,7 +8076,11 @@ validate.schema = {
       "additionalProperties": false,
       "properties": {
         "property": {
-          "type": "string"
+          "anyOf": [{
+            "type": "string"
+          }, {
+            "type": "object"
+          }]
         },
         "direction": {
           "$ref": "#/definitions/Direction"
@@ -7793,6 +8132,18 @@ validate.schema = {
         },
         "create": {
           "type": "string"
+        },
+        "restrict": {
+          "type": "object",
+          "properties": {
+            "origin": {
+              "type": "string"
+            },
+            "destination": {
+              "type": "string",
+              "enum": ["same", "different", "all"]
+            }
+          }
         }
       },
       "required": [],
@@ -7825,7 +8176,11 @@ validate.schema = {
       "additionalProperties": false,
       "properties": {
         "layoutVariable": {
-          "type": "string"
+          "anyOf": [{
+            "type": "string"
+          }, {
+            "type": "object"
+          }]
         },
         "allowPositioning": {
           "type": "boolean"

--- a/schemas/8.json
+++ b/schemas/8.json
@@ -120,6 +120,8 @@
             },
             {
               "type": "array",
+              "minItems": 1,
+              "maxItems": 2,
               "items": {
                 "$ref": "#/definitions/Subject"
               }

--- a/schemas/8.json
+++ b/schemas/8.json
@@ -114,7 +114,17 @@
           "type": ["string", "null"]
         },
         "subject": {
-          "$ref": "#/definitions/Subject"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Subject"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Subject"
+              }
+            }
+          ]
         },
         "panels": {
           "type": "array",
@@ -606,7 +616,14 @@
       "additionalProperties": false,
       "properties": {
         "property": {
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ]
         },
         "direction": {
           "$ref": "#/definitions/Direction"
@@ -658,6 +675,18 @@
         },
         "create": {
           "type": "string"
+        },
+        "restrict": {
+          "type": "object",
+          "properties": {
+            "origin": {
+              "type": "string"
+            },
+            "destination": {
+              "type": "string",
+              "enum": ["same", "different", "all"]
+            }
+          }
         }
       },
       "required": [],
@@ -690,7 +719,14 @@
       "additionalProperties": false,
       "properties": {
         "layoutVariable": {
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ]
         },
         "allowPositioning": {
           "type": "boolean"

--- a/schemas/8.json
+++ b/schemas/8.json
@@ -618,20 +618,22 @@
       "additionalProperties": false,
       "properties": {
         "property": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "object"
-            }
-          ]
+          "type": "string"
         },
         "direction": {
           "$ref": "#/definitions/Direction"
+        },
+        "type": {
+          "enum": ["string", "number", "boolean", "date", "hierarchy"]
+        },
+        "hierarchy": {
+          "type": "array",
+          "items": {
+            "type": ["string", "number", "boolean"]
+          }
         }
       },
-      "required": ["direction", "property"],
+      "required": ["property"],
       "title": "SortOrder"
     },
     "CardOptions": {

--- a/validation/__tests__/__snapshots__/validateLogic.test.js.snap
+++ b/validation/__tests__/__snapshots__/validateLogic.test.js.snap
@@ -3,14 +3,7 @@
 exports[`validateLogic A well formed protocol will return an array of errors 1`] = `
 Array [
   "protocol.codebook: Duplicate entity name \\"du\\"",
-  "protocol.stages[0].subject: Only the sociogram may use multiple node types",
   "protocol.stages[0].form.fields[0]: Form field variable not found in codebook.",
-  "protocol.stages[1].subject: Only the sociogram may use multiple node types",
-  "protocol.stages[2].subject: Only the sociogram may use multiple node types",
-  "protocol.stages[3].subject: Only the sociogram may use multiple node types",
-  "protocol.stages[4].subject: Only the sociogram may use multiple node types",
-  "protocol.stages[5].subject: Only the sociogram may use multiple node types",
   "protocol.stages[5].form.fields[0]: Form field variable not found in codebook.",
-  "protocol.stages[6].subject: Only the sociogram may use multiple node types",
 ]
 `;

--- a/validation/__tests__/__snapshots__/validateLogic.test.js.snap
+++ b/validation/__tests__/__snapshots__/validateLogic.test.js.snap
@@ -3,7 +3,14 @@
 exports[`validateLogic A well formed protocol will return an array of errors 1`] = `
 Array [
   "protocol.codebook: Duplicate entity name \\"du\\"",
+  "protocol.stages[0].subject: Only the sociogram may use multiple node types",
   "protocol.stages[0].form.fields[0]: Form field variable not found in codebook.",
+  "protocol.stages[1].subject: Only the sociogram may use multiple node types",
+  "protocol.stages[2].subject: Only the sociogram may use multiple node types",
+  "protocol.stages[3].subject: Only the sociogram may use multiple node types",
+  "protocol.stages[4].subject: Only the sociogram may use multiple node types",
+  "protocol.stages[5].subject: Only the sociogram may use multiple node types",
   "protocol.stages[5].form.fields[0]: Form field variable not found in codebook.",
+  "protocol.stages[6].subject: Only the sociogram may use multiple node types",
 ]
 `;

--- a/validation/validateLogic.js
+++ b/validation/validateLogic.js
@@ -260,6 +260,14 @@ const validateLogic = (protocol) => {
     additionalAttributes => `One or more sortable properties not defined in codebook: ${additionalAttributes.map(({ variable }) => variable)}`,
   );
 
+  // Sociogram prompt edges key can contain a restrict object.
+
+  // If restrict.origin is present, its value must be a valid node type.
+  v.addValidation('prompts[].edges.restrict.origin',
+    origin => Object.keys(codebook.node).includes(origin),
+    origin => `"${origin}" is not a valid node type.`,
+  );
+
   v.runValidations();
 
   v.warnings.forEach(warning => console.error(warning)); // eslint-disable-line no-console


### PR DESCRIPTION
Enables protocol validation features for two-mode sociograms:

- [x] Allows `subject` to be a collection on sociogram stages
- [x] Adds a `restrict` object to `prompts[].edges` that constrains edge creation
- [x] Extends `sortOrder` definition to allow `sortOrder.property` to be an object keyed by node type. 
~~- [ ] TODO: validate types and variables of above~~ not possible with JSON schema currently
- [x] Extends `prompt.layout.layoutVariable` to support being an object keyed by node type 
  - [ ] TODO: validate types and variables of above