### PR TITLE
Fix logic validations not being applied to ego variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "protocol-validation",
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
@@ -20,11 +21,11 @@
         "eslint-plugin-jsx-a11y": "5.1.1",
         "eslint-plugin-react": "^7.11.1",
         "fs-extra": "^8.0.1",
-        "jszip": "^3.2.1"
+        "jszip": "^3.2.1",
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
-        "jest": "^24.8.0",
-        "lodash": "^4.17.21"
+        "jest": "^24.8.0"
       },
       "engines": {
         "node": "12.14.1",

--- a/validation/Validator.js
+++ b/validation/Validator.js
@@ -36,13 +36,18 @@ const makePattern = (pattern) => {
   return pattern;
 };
 
-const keypathString = keypath =>
-  keypath.reduce((acc, path) => {
+const keypathString = (keypath) => {
+  if (typeof keypath === 'string') {
+    return keypath;
+  }
+
+  return keypath.reduce((acc, path) => {
     if ((/\[\d+\]/).test(path)) {
       return `${acc}${path}`;
     }
     return `${acc}.${path}`;
   });
+}
 
 /**
  * @class


### PR DESCRIPTION
Two validation rules were not being applied to ego variables.

  - Validation of variable validation that references other variables (sameAs, differentFrom, greaterThanVariable, lessThanVariable)
  - Validation that variable name is unique

Both issues are fixed here by using a regexp directly to specify the validation target, and then adding specific logic to deal with parsing the ego codebook.

This technically represents a breaking change within the schema, but in practice we have no bandwidth to properly handle the migration, and very little reason to believe that protocols exist that are broken due to this issue.