### PR TITLE
Fix code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -24,6 +24,7 @@ import { ValidationError } from "..";
 const ensurePatternRegExp = (pattern: string | RegExp): RegExp => {
   if (typeof pattern === "string") {
     const re = pattern
+      .replace(/\\/g, "\\\\")
       .replace(/\./g, "\\.")
       .replace(/\*/g, "[^.]+")
       .replace(/\[\]/g, ".?\\[\\d+\\]");


### PR DESCRIPTION
Fixes [https://github.com/complexdatacollective/protocol-validation/security/code-scanning/1](https://github.com/complexdatacollective/protocol-validation/security/code-scanning/1)

To fix the problem, we need to ensure that backslashes in the input string are properly escaped before converting the string into a regular expression. This can be done by adding an additional `replace` call to escape backslashes. The best way to fix this without changing existing functionality is to add `.replace(/\\/g, "\\\\")` to the chain of `replace` calls.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
